### PR TITLE
Complementary Filter was added to improve IMU orientation

### DIFF
--- a/easynav_gps_localizer/include/easynav_gps_localizer/GpsLocalizer.hpp
+++ b/easynav_gps_localizer/include/easynav_gps_localizer/GpsLocalizer.hpp
@@ -31,8 +31,8 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_ros/static_transform_broadcaster.h"
 #include "sensor_msgs/msg/imu.hpp"
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
 #include <GeographicLib/UTMUPS.hpp>
 
 namespace easynav
@@ -108,6 +108,15 @@ private:
    */
   geometry_msgs::msg::Point origin_utm_;
 
+  /** 
+   * @brief odometry publisher
+   * 
+   * This publisher publsh in a topic the odom value
+   * It is used to validate the localization
+  */
+
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+
   /**
    * @brief Subscriber for GPS data.
    *
@@ -169,7 +178,7 @@ private:
    */
   void imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg);
 
-  double alpha_, yaw_gyro_, dt_, yaw_1_, yaw_filtered_, time_1_;
+  double alpha_, dt_, yaw_1_, time_1_;
 };
 
 }  // namespace easynav

--- a/easynav_gps_localizer/include/easynav_gps_localizer/GpsLocalizer.hpp
+++ b/easynav_gps_localizer/include/easynav_gps_localizer/GpsLocalizer.hpp
@@ -31,8 +31,8 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_ros/static_transform_broadcaster.h"
 #include "sensor_msgs/msg/imu.hpp"
-#include <tf2/LinearMath/Quaternion.hpp>
-#include <tf2/LinearMath/Matrix3x3.hpp>
+#include "tf2/LinearMath/Quaternion.hpp"
+#include "tf2/LinearMath/Matrix3x3.hpp"
 #include <GeographicLib/UTMUPS.hpp>
 
 namespace easynav
@@ -114,7 +114,6 @@ private:
    * This publisher publsh in a topic the odom value
    * It is used to validate the localization
   */
-
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
 
   /**

--- a/easynav_gps_localizer/include/easynav_gps_localizer/GpsLocalizer.hpp
+++ b/easynav_gps_localizer/include/easynav_gps_localizer/GpsLocalizer.hpp
@@ -31,6 +31,8 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_ros/static_transform_broadcaster.h"
 #include "sensor_msgs/msg/imu.hpp"
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
 #include <GeographicLib/UTMUPS.hpp>
 
 namespace easynav
@@ -166,6 +168,8 @@ private:
    * @param msg The IMU data message.
    */
   void imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg);
+
+  double alpha_, yaw_gyro_, dt_, yaw_1_, yaw_filtered_, time_1_;
 };
 
 }  // namespace easynav

--- a/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
+++ b/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
@@ -50,6 +50,10 @@ std::expected<void, std::string> GpsLocalizer::on_initialize()
     "imu/data", rclcpp::SensorDataQoS().reliable(),
     std::bind(&GpsLocalizer::imu_callback, this, std::placeholders::_1));
 
+  // Create publisher
+  odom_pub_ = node->create_publisher<nav_msgs::msg::Odometry>(
+    "robot/odom_gps", 10);
+
   // Create static transform
   geometry_msgs::msg::TransformStamped transform;
   transform.header.stamp = node->now();
@@ -67,7 +71,7 @@ std::expected<void, std::string> GpsLocalizer::on_initialize()
   RTTFBuffer::getInstance()->setTransform(transform, "easynav", true);
 
   time_1_ = get_node()->now().seconds();
-  alpha_ = 0.98;
+  alpha_ = 0.99;
 
   return {};
 }
@@ -93,7 +97,7 @@ void GpsLocalizer::update(NavState & nav_state)
   // Convert GPS coordinates to UTM
   double lat = gps_msg_.latitude;
   double lon = gps_msg_.longitude;
-  double utm_x, utm_y, roll, pitch, yaw_imu;
+  double utm_x, utm_y, roll, pitch, yaw_imu, yaw_gyro, yaw_filtered;
   int zone;
   bool northp;
 
@@ -117,10 +121,7 @@ void GpsLocalizer::update(NavState & nav_state)
 
   // Extract the yaw angle from the IMU data
   dt_ = get_node()->now().seconds() - time_1_;
-  yaw_gyro_ = yaw_1_ + imu_msg_.angular_velocity.z * dt_;
-
-  // Yaw angle filtered using a complementary filter
-  yaw_filtered_ = (yaw_gyro_ * alpha_) + (yaw_imu * (1 - alpha_));
+  yaw_gyro = yaw_1_ + imu_msg_.angular_velocity.z * dt_;
 
   tf2::Quaternion q(
     imu_msg_.orientation.x,
@@ -130,18 +131,22 @@ void GpsLocalizer::update(NavState & nav_state)
   tf2::Matrix3x3 m(q);
   m.getRPY(roll, pitch, yaw_imu);
 
+  // Yaw angle filtered using a complementary filter
+  yaw_filtered = (yaw_imu * alpha_) + (yaw_gyro * (1 - alpha_));
+
   // Extract the yaw angle from the IMU data
   tf2::Quaternion q_filtered;
-  q_filtered.setRPY(roll, pitch, yaw_filtered_);
+  q_filtered.setRPY(roll, pitch, yaw_filtered);
   odom_.pose.pose.orientation.x = q_filtered.x();
   odom_.pose.pose.orientation.y = q_filtered.y();
   odom_.pose.pose.orientation.z = q_filtered.z();
   odom_.pose.pose.orientation.w = q_filtered.w();
   // odom_.pose.pose.orientation = imu_msg_.orientation;
-  yaw_1_ = yaw_filtered_;
+  yaw_1_ = yaw_filtered;
   time_1_ = get_node()->now().seconds();
 
   nav_state.set("robot_pose", odom_);
+  odom_pub_->publish(odom_);
 }
 
 }  // namespace easynav

--- a/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
+++ b/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
@@ -132,7 +132,7 @@ void GpsLocalizer::update(NavState & nav_state)
   m.getRPY(roll, pitch, yaw_imu);
 
   // Yaw angle filtered using a complementary filter
-  yaw_filtered = (yaw_imu * alpha_) + (yaw_gyro * (1 - alpha_));
+  yaw_filtered = (yaw_gyro * alpha_) + (yaw_imu * (1 - alpha_));
 
   // Extract the yaw angle from the IMU data
   tf2::Quaternion q_filtered;
@@ -142,7 +142,7 @@ void GpsLocalizer::update(NavState & nav_state)
   odom_.pose.pose.orientation.z = q_filtered.z();
   odom_.pose.pose.orientation.w = q_filtered.w();
   // odom_.pose.pose.orientation = imu_msg_.orientation;
-  yaw_1_ = yaw_filtered;
+  yaw_1_ = yaw_gyro;
   time_1_ = get_node()->now().seconds();
 
   nav_state.set("robot_pose", odom_);

--- a/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
+++ b/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
@@ -52,7 +52,7 @@ std::expected<void, std::string> GpsLocalizer::on_initialize()
 
   // Create publisher
   odom_pub_ = node->create_publisher<nav_msgs::msg::Odometry>(
-    "robot/odom_gps", 10);
+    "robot/odom_gps", rclcpp::SensorDataQoS().reliable());
 
   // Create static transform
   geometry_msgs::msg::TransformStamped transform;
@@ -141,7 +141,6 @@ void GpsLocalizer::update(NavState & nav_state)
   odom_.pose.pose.orientation.y = q_filtered.y();
   odom_.pose.pose.orientation.z = q_filtered.z();
   odom_.pose.pose.orientation.w = q_filtered.w();
-  // odom_.pose.pose.orientation = imu_msg_.orientation;
   yaw_1_ = yaw_gyro;
   time_1_ = get_node()->now().seconds();
 

--- a/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
+++ b/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
@@ -66,6 +66,9 @@ std::expected<void, std::string> GpsLocalizer::on_initialize()
 
   RTTFBuffer::getInstance()->setTransform(transform, "easynav", true);
 
+  time_1_ = get_node()->now().seconds();
+  alpha_ = 0.98;
+
   return {};
 }
 
@@ -90,7 +93,7 @@ void GpsLocalizer::update(NavState & nav_state)
   // Convert GPS coordinates to UTM
   double lat = gps_msg_.latitude;
   double lon = gps_msg_.longitude;
-  double utm_x, utm_y;
+  double utm_x, utm_y, roll, pitch, yaw_imu;
   int zone;
   bool northp;
 
@@ -113,7 +116,30 @@ void GpsLocalizer::update(NavState & nav_state)
   odom_.pose.pose.position.y = utm_y - origin_utm_.y;
 
   // Extract the yaw angle from the IMU data
-  odom_.pose.pose.orientation = imu_msg_.orientation;
+  dt_ = get_node()->now().seconds() - time_1_;
+  yaw_gyro_ = yaw_1_ + imu_msg_.angular_velocity.z * dt_;
+
+  // Yaw angle filtered using a complementary filter
+  yaw_filtered_ = (yaw_gyro_ * alpha_) + (yaw_imu * (1 - alpha_));
+
+  tf2::Quaternion q(
+    imu_msg_.orientation.x,
+    imu_msg_.orientation.y,
+    imu_msg_.orientation.z,
+    imu_msg_.orientation.w);
+  tf2::Matrix3x3 m(q);
+  m.getRPY(roll, pitch, yaw_imu);
+
+  // Extract the yaw angle from the IMU data
+  tf2::Quaternion q_filtered;
+  q_filtered.setRPY(roll, pitch, yaw_filtered_);
+  odom_.pose.pose.orientation.x = q_filtered.x();
+  odom_.pose.pose.orientation.y = q_filtered.y();
+  odom_.pose.pose.orientation.z = q_filtered.z();
+  odom_.pose.pose.orientation.w = q_filtered.w();
+  // odom_.pose.pose.orientation = imu_msg_.orientation;
+  yaw_1_ = yaw_filtered_;
+  time_1_ = get_node()->now().seconds();
 
   nav_state.set("robot_pose", odom_);
 }


### PR DESCRIPTION
Hi,

In this PR was included a complementary filter to improve the orientation provided by IMU. 

The result is exposed as follow where yellow arrow is ground truth and frame is odometry using GPS:
![image](https://github.com/user-attachments/assets/57b9707b-2259-4aab-8f58-2bbbbac04d61)

The error was not calculated but VFF controller works. 

Regards,

JuanS.