### PR TITLE
Include perceptions in cost computation if available

### DIFF
--- a/easynav_mppi_controller/CMakeLists.txt
+++ b/easynav_mppi_controller/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common io)
 
 
 add_library(${PROJECT_NAME} SHARED
@@ -26,6 +27,7 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  ${PCL_INCLUDE_DIRS}
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
   easynav_common::easynav_common
@@ -35,6 +37,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   ${geometry_msgs_TARGETS}
   ${nav_msgs_TARGETS}
   ${visualization_msgs_TARGETS}
+  ${PCL_LIBRARIES}
 )
 
 install(
@@ -75,6 +78,6 @@ ament_export_dependencies(
   geometry_msgs
   nav_msgs
   visualization_msgs
-
 )
+
 ament_package()

--- a/easynav_mppi_controller/include/easynav_mppi_controller/MPPIController.hpp
+++ b/easynav_mppi_controller/include/easynav_mppi_controller/MPPIController.hpp
@@ -52,6 +52,8 @@ protected:
   double lambda_{0.1};        ///< Temperature parameter for MPPI.
   double max_lin_vel_{1.0};   ///< Maximum linear velocity for MPPI.
   double max_ang_vel_{1.0};   ///< Maximum angular velocity for MPPI.
+  double max_lin_acc_{0.5};   ///< Maximum linear acceleration for MPPI.
+  double max_ang_acc_{1.0};   ///< Maximum angular acceleration for MPPI.
   double fov_{M_PI / 2.0};    ///< Field of view for MPPI.
   double safety_radius_{0.6}; ///< Safety radius for obstacle avoidance.
 

--- a/easynav_mppi_controller/include/easynav_mppi_controller/MPPIController.hpp
+++ b/easynav_mppi_controller/include/easynav_mppi_controller/MPPIController.hpp
@@ -23,6 +23,7 @@
 
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
 
 namespace easynav
 {
@@ -45,10 +46,14 @@ public:
   void update_rt(NavState & nav_state) override;
 
 protected:
-  int num_samples_{100};  ///< Number of samples for MPPI.
-  int horizon_steps_{10}; ///< Prediction horizon for MPPI.
-  double dt_{0.1};        ///< Time step for MPPI.
-  double lambda_{0.1};    ///< Temperature parameter for MPPI.
+  int num_samples_{100};      ///< Number of samples for MPPI.
+  int horizon_steps_{10};     ///< Prediction horizon for MPPI.
+  double dt_{0.1};            ///< Time step for MPPI.
+  double lambda_{0.1};        ///< Temperature parameter for MPPI.
+  double max_lin_vel_{1.0};   ///< Maximum linear velocity for MPPI.
+  double max_ang_vel_{1.0};   ///< Maximum angular velocity for MPPI.
+  double fov_{M_PI / 2.0};    ///< Field of view for MPPI.
+  double safety_radius_{0.6}; ///< Safety radius for obstacle avoidance.
 
   geometry_msgs::msg::TwistStamped twist_stamped_;  ///< Current velocity command.
 

--- a/easynav_mppi_controller/include/easynav_mppi_controller/MPPIOptimizer.hpp
+++ b/easynav_mppi_controller/include/easynav_mppi_controller/MPPIOptimizer.hpp
@@ -14,6 +14,8 @@
 
 #include "geometry_msgs/msg/pose.hpp"
 #include "nav_msgs/msg/path.hpp"
+#include "pcl/point_cloud.h"
+#include "pcl/point_types.h"
 
 namespace easynav
 {
@@ -42,30 +44,34 @@ public:
   /// \param horizon_steps Number of steps in the prediction horizon.
   /// \param dt Time step for the simulation.
   /// \param lambda Temperature parameter for MPPI.
+  /// \param max_lin_vel Maximum linear velocity in m/s.
+  /// \param max_ang_vel Maximum angular velocity in rad/s.
+  /// \param fov Field of view in radians for trajectory sampling.
+  /// \param safety_radius Safety radius for obstacle avoidance in meters.
   MPPIOptimizer(
     double num_samples, double horizon_steps, double dt, double lambda,
-    double max_lin_vel = 1.0, double max_ang_vel = 1.0, double fov = M_PI / 2.0);
+    double max_lin_vel = 1.0, double max_ang_vel = 1.0, double fov = M_PI / 2.0,
+    double safety_radius = 0.6);
 
   /// \brief Computes the control commands using MPPI optimization.
   /// \param current_pose Current pose of the robot.
   /// \param path Planned path to follow.
+  /// \param points Point cloud of the environment.
   /// \return MPPIResult containing the best control commands and trajectories.
   MPPIResult compute_control(
     const geometry_msgs::msg::Pose & current_pose,
-    const nav_msgs::msg::Path & path);
+    const nav_msgs::msg::Path & path,
+    const pcl::PointCloud<pcl::PointXYZ> & points);
 
 private:
-  const double ANGLE_THRESHOLD = 0.35; ///< Threshold for angle alignment with the goal in radians.
-  const double ROT_SPEED = 0.5; ///< Maximum angular speed in radians per second.
-
   double num_samples_;    ///< Number of samples to generate for MPPI.
   double horizon_steps_;  ///< Number of steps in the prediction horizon.
   double dt_;             ///< Time step for the simulation.
   double lambda_;         ///< Temperature parameter for MPPI.
-
-  double max_lin_vel_; ///< Maximum linear velocity in m/s.
-  double max_ang_vel_; ///< Maximum angular velocity in rad/s.
-  double fov_;  //< Field of view in radians for trajectory sampling.
+  double max_lin_vel_;    ///< Maximum linear velocity in m/s.
+  double max_ang_vel_;    ///< Maximum angular velocity in rad/s.
+  double fov_;            ///< Field of view in radians for trajectory sampling.
+  double safety_radius_;  ///< Safety radius for obstacle avoidance in meters.
 
   std::default_random_engine rng_; ///< Random number generator for sampling.
   std::normal_distribution<double> normal_ = std::normal_distribution<double>(0.0, 0.5); ///< Normal distribution for noise in sampling.
@@ -76,11 +82,13 @@ private:
   /// \param v Linear velocity of the trajectory.
   /// \param w Angular velocity of the trajectory.
   /// \param initial_yaw Initial yaw orientation of the robot.
+  /// \param points The point cloud of the environment.
   /// \return The computed cost of the trajectory.
   double compute_cost(
     const std::vector<std::pair<double, double>> & trajectory,
     const nav_msgs::msg::Path & path,
-    double v, double w, double initial_yaw);
+    double v, double w, double initial_yaw,
+    const pcl::PointCloud<pcl::PointXYZ> & points);
 
   /// \brief Simulates a trajectory based on initial position, orientation, and velocities.
   /// \param x Initial x position.

--- a/easynav_mppi_controller/include/easynav_mppi_controller/MPPIOptimizer.hpp
+++ b/easynav_mppi_controller/include/easynav_mppi_controller/MPPIOptimizer.hpp
@@ -46,12 +46,14 @@ public:
   /// \param lambda Temperature parameter for MPPI.
   /// \param max_lin_vel Maximum linear velocity in m/s.
   /// \param max_ang_vel Maximum angular velocity in rad/s.
+  /// \param max_lin_acc Maximum linear acceleration in m/s^2.
+  /// \param max_ang_acc Maximum angular acceleration in rad/s^2.
   /// \param fov Field of view in radians for trajectory sampling.
   /// \param safety_radius Safety radius for obstacle avoidance in meters.
   MPPIOptimizer(
     double num_samples, double horizon_steps, double dt, double lambda,
-    double max_lin_vel = 1.0, double max_ang_vel = 1.0, double fov = M_PI / 2.0,
-    double safety_radius = 0.6);
+    double max_lin_vel = 1.0, double max_ang_vel = 1.0, double max_lin_acc = 1.0, 
+    double max_ang_acc = 1.0, double fov = M_PI / 2.0, double safety_radius = 0.6);
 
   /// \brief Computes the control commands using MPPI optimization.
   /// \param current_pose Current pose of the robot.
@@ -70,11 +72,17 @@ private:
   double lambda_;         ///< Temperature parameter for MPPI.
   double max_lin_vel_;    ///< Maximum linear velocity in m/s.
   double max_ang_vel_;    ///< Maximum angular velocity in rad/s.
+  double max_lin_acc_;    ///< Maximum linear acceleration in m/s^2.
+  double max_ang_acc_;    ///< Maximum angular acceleration in rad/s^2.
   double fov_;            ///< Field of view in radians for trajectory sampling.
   double safety_radius_;  ///< Safety radius for obstacle avoidance in meters.
+  double last_v_ = 0.0;   ///< Last linear velocity command for smoothing.
+  double last_w_ = 0.0;   ///< Last angular velocity command for smoothing.
 
   std::default_random_engine rng_; ///< Random number generator for sampling.
-  std::normal_distribution<double> normal_ = std::normal_distribution<double>(0.0, 0.5); ///< Normal distribution for noise in sampling.
+  std::normal_distribution<double> normal_ = std::normal_distribution<double>(0.0, 0.5);    ///< Normal distribution for noise in sampling.
+  std::normal_distribution<double> v_noise_ = std::normal_distribution<double>(0.0, 0.05);  ///< Normal distribution for noise in linear velocity.
+  std::normal_distribution<double> w_noise_ = std::normal_distribution<double>(0.0, 0.02);  ///< Normal distribution for noise in angular velocity.
 
   /// \brief Computes the cost of a trajectory based on its distance to the path and heading error.
   /// \param trajectory The trajectory to evaluate.
@@ -96,10 +104,12 @@ private:
   /// \param yaw Initial yaw orientation.
   /// \param v Linear velocity.
   /// \param w Angular velocity.
+  /// \param path The planned path to follow.
+  /// \param steps Number of steps to simulate.
   /// \return The simulated trajectory.
   std::vector<std::pair<double, double>> simulate_trajectory(
     double x, double y, double yaw,
-    double v, double w);
+    double v, double w, const nav_msgs::msg::Path & path, int steps);
 
   /// \brief Computes the heading error between the robot's current orientation and the target point.
   /// \param robot_yaw Current yaw orientation of the robot.

--- a/easynav_mppi_controller/package.xml
+++ b/easynav_mppi_controller/package.xml
@@ -16,6 +16,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>pcl_ros</depend>
 
   <test_depend>rclcpp_lifecycle</test_depend>
   <test_depend>easynav_simple_common</test_depend>

--- a/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
+++ b/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
@@ -49,6 +49,8 @@ MPPIController::on_initialize()
   node->declare_parameter<double>(plugin_name + ".lambda", lambda_);
   node->declare_parameter<double>(plugin_name + ".max_linear_velocity", max_lin_vel_);
   node->declare_parameter<double>(plugin_name + ".max_angular_velocity", max_ang_vel_);
+  node->declare_parameter<double>(plugin_name + ".max_linear_acceleration", max_lin_acc_);
+  node->declare_parameter<double>(plugin_name + ".max_angular_acceleration", max_ang_acc_);
   node->declare_parameter<double>(plugin_name + ".fov", fov_);
   node->declare_parameter<double>(plugin_name + ".safety_radius", safety_radius_);
 
@@ -58,6 +60,8 @@ MPPIController::on_initialize()
   node->get_parameter<double>(plugin_name + ".lambda", lambda_);
   node->get_parameter<double>(plugin_name + ".max_linear_velocity", max_lin_vel_);
   node->get_parameter<double>(plugin_name + ".max_angular_velocity", max_ang_vel_);
+  node->get_parameter<double>(plugin_name + ".max_linear_acceleration", max_lin_acc_);
+  node->get_parameter<double>(plugin_name + ".max_angular_acceleration", max_ang_acc_);
   node->get_parameter<double>(plugin_name + ".fov", fov_);
   node->get_parameter<double>(plugin_name + ".safety_radius", safety_radius_);
 

--- a/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
+++ b/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
@@ -25,6 +25,8 @@
 #include "tf2/utils.hpp"
 
 #include "easynav_mppi_controller/MPPIController.hpp"
+#include "easynav_common/types/Perceptions.hpp"
+#include "easynav_common/types/PointPerception.hpp"
 
 #include "nav_msgs/msg/odometry.hpp"
 
@@ -45,13 +47,22 @@ MPPIController::on_initialize()
   node->declare_parameter<int>(plugin_name + ".horizon_steps", horizon_steps_);
   node->declare_parameter<double>(plugin_name + ".dt", dt_);
   node->declare_parameter<double>(plugin_name + ".lambda", lambda_);
+  node->declare_parameter<double>(plugin_name + ".max_linear_velocity", max_lin_vel_);
+  node->declare_parameter<double>(plugin_name + ".max_angular_velocity", max_ang_vel_);
+  node->declare_parameter<double>(plugin_name + ".fov", fov_);
+  node->declare_parameter<double>(plugin_name + ".safety_radius", safety_radius_);
 
   node->get_parameter<int>(plugin_name + ".num_samples", num_samples_);
   node->get_parameter<int>(plugin_name + ".horizon_steps", horizon_steps_);
   node->get_parameter<double>(plugin_name + ".dt", dt_);
   node->get_parameter<double>(plugin_name + ".lambda", lambda_);
+  node->get_parameter<double>(plugin_name + ".max_linear_velocity", max_lin_vel_);
+  node->get_parameter<double>(plugin_name + ".max_angular_velocity", max_ang_vel_);
+  node->get_parameter<double>(plugin_name + ".fov", fov_);
+  node->get_parameter<double>(plugin_name + ".safety_radius", safety_radius_);
 
-  optimizer_ = std::make_unique<MPPIOptimizer>(num_samples_, horizon_steps_, dt_, lambda_);
+  optimizer_ = std::make_unique<MPPIOptimizer>(num_samples_, horizon_steps_, dt_, lambda_,
+    max_lin_vel_, max_ang_vel_, fov_, safety_radius_);
 
   mppi_candidates_pub_ =
     node->create_publisher<visualization_msgs::msg::MarkerArray>("/mppi/candidates", 10);
@@ -153,9 +164,23 @@ MPPIController::update_rt(NavState & nav_state)
   }
 
   const auto pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
+  const auto perceptions = nav_state.get<PointPerceptions>("points");
 
-  // Compute the control using MPPI
-  auto result = optimizer_->compute_control(pose, path);
+  const auto & filtered = PointPerceptionsOpsView(perceptions)
+    .filter({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0})
+    .fuse("map")
+    ->filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
+    .collapse({NAN, NAN, 0.1})
+    ->downsample(0.1)
+    .as_points();
+
+  if (filtered.empty()) {
+    RCLCPP_WARN(get_node()->get_logger(),
+        "No valid points available for MPPI optimization, using the path only.");
+  }
+
+  // Compute the control using MPPI with points
+  auto result = optimizer_->compute_control(pose, path, filtered);
 
   // Publish the computed velocity command
   twist_stamped_.header.frame_id = path.header.frame_id;

--- a/easynav_mppi_controller/src/easynav_mppi_controller/MPPIOptimizer.cpp
+++ b/easynav_mppi_controller/src/easynav_mppi_controller/MPPIOptimizer.cpp
@@ -14,22 +14,48 @@ namespace easynav
 
 MPPIOptimizer::MPPIOptimizer(
   double num_samples, double horizon_steps, double dt, double lambda,
-  double max_lin_vel, double max_ang_vel, double fov, double safety_radius)
+  double max_lin_vel, double max_ang_vel, double max_lin_acc, double max_ang_acc,
+  double fov, double safety_radius)
 : num_samples_(num_samples), horizon_steps_(horizon_steps), dt_(dt), lambda_(lambda),
-  max_lin_vel_(max_lin_vel), max_ang_vel_(max_ang_vel), fov_(fov), safety_radius_(safety_radius)
+  max_lin_vel_(max_lin_vel), max_ang_vel_(max_ang_vel), max_lin_acc_(max_lin_acc), max_ang_acc_(max_ang_acc),
+  fov_(fov), safety_radius_(safety_radius)
 {
 }
 
 std::vector<std::pair<double, double>>
-MPPIOptimizer::simulate_trajectory(double x, double y, double yaw, double v, double w)
+MPPIOptimizer::simulate_trajectory(
+  double x, double y, double yaw, double v, double w,
+  const nav_msgs::msg::Path & path, int steps)
 {
+  size_t horizon_steps = static_cast<size_t>(steps);
   std::vector<std::pair<double, double>> trajectory;
-  trajectory.reserve(static_cast<size_t>(horizon_steps_));
-  // Simulate trajectory: generate points based on velocity and angular velocity
-  for (int i = 0; i < static_cast<int>(horizon_steps_); ++i) {
-    x += v * std::cos(yaw) * dt_;
-    y += v * std::sin(yaw) * dt_;
-    yaw += w * dt_;
+  trajectory.reserve(horizon_steps);
+
+  bool has_path = !path.poses.empty();
+
+  for (size_t i = 0; i < horizon_steps; ++i) {
+    // MPPI noise sampling
+    double v_sample = v + normal_(rng_);
+    double w_sample = w + normal_(rng_);
+
+    // Differential drive kinematics
+    x += v_sample * std::cos(yaw) * dt_;
+    y += v_sample * std::sin(yaw) * dt_;
+    yaw += w_sample * dt_;
+
+    if (has_path) {
+      // Calculate the index in the path based on the current step
+      size_t path_idx = std::min(static_cast<size_t>((i * path.poses.size()) / horizon_steps),
+          path.poses.size() - 1);
+      double target_x = path.poses[path_idx].pose.position.x;
+      double target_y = path.poses[path_idx].pose.position.y;
+
+      // Smooth motion towards the target
+      double alpha = 0.2;
+      x += alpha * (target_x - x);
+      y += alpha * (target_y - y);
+    }
+
     trajectory.emplace_back(x, y);
   }
 
@@ -57,42 +83,37 @@ double MPPIOptimizer::compute_cost(
   const std::vector<std::pair<double, double>> & trajectory,
   const nav_msgs::msg::Path & path,
   double v, double w, double initial_yaw,
-  const pcl::PointCloud<pcl::PointXYZ> & points
-)
+  const pcl::PointCloud<pcl::PointXYZ> & points)
 {
   // Total cost accumulator
   double cost = 0.0;
+  size_t path_size = path.poses.size();
 
   // --- Path-Tracking Penalties ---
   for (size_t i = 0; i < trajectory.size(); ++i) {
     const auto &[x, y] = trajectory[i];
 
-    double min_dist = std::numeric_limits<double>::max();
-    double heading_penalty = 0.0;
-    double fov_penalty = 0.0;
+    // Cost is distributed along the trajectory
+    double path_alpha = static_cast<double>(i) / trajectory.size();
+    size_t idx = std::min(static_cast<size_t>(path_alpha * path_size), path_size - 1);
 
-    // Distance to path: encourage staying close to planned path
-    for (const auto & pose_stamped : path.poses) {
-      double dx = pose_stamped.pose.position.x - x;
-      double dy = pose_stamped.pose.position.y - y;
-      double dist = std::hypot(dx, dy);
-      if (dist < min_dist) {
-        min_dist = dist;
-        // Heading alignment with nearest path point
-        heading_penalty = heading_error(
-          initial_yaw, pose_stamped.pose.position.x, pose_stamped.pose.position.y, x, y);
-      }
-    }
+    double dx = path.poses[idx].pose.position.x - x;
+    double dy = path.poses[idx].pose.position.y - y;
+    double dist = std::hypot(dx, dy);
+
+    // Heading error is calculated based on the initial yaw
+    double heading_penalty = heading_error(initial_yaw, path.poses[idx].pose.position.x,
+                                               path.poses[idx].pose.position.y, x, y);
 
     // FOV penalty: discourage trajectories outside robot's view
-    double angle_to_target = heading_error(initial_yaw, trajectory.back().first,
-        trajectory.back().second, x, y);
-    fov_penalty = 0.5 * std::pow(std::max(0.0, angle_to_target - fov_), 2);
+    double angle_to_goal = heading_error(initial_yaw, trajectory.back().first,
+                                             trajectory.back().second, x, y);
+    double fov_penalty = std::pow(std::max(0.0, angle_to_goal - fov_), 2);
 
     // Accumulate penalties
-    cost += min_dist;                // distance to path
-    cost += 0.1 * heading_penalty;   // heading misalignment
-    cost += 0.5 * fov_penalty;       // leaving field of view
+    cost += dist;                // distance to path
+    cost += 0.05 * heading_penalty;   // heading misalignment
+    cost += 0.2 * fov_penalty;       // leaving field of view
   }
 
   // --- Goal Progress Penalties ---
@@ -112,7 +133,6 @@ double MPPIOptimizer::compute_cost(
   cost += -2.0 * progress;   // reward moving closer to goal
   cost += 1.5 * d_end_goal;  // penalize being far from goal at end
 
-
   // --- Obstacle Avoidance Penalties ---
   double min_obs_overall = std::numeric_limits<double>::max();
 
@@ -129,7 +149,7 @@ double MPPIOptimizer::compute_cost(
     // Safety margin (robot radius + margin)
     if (min_obs_dist < safety_radius_) {
       // Heavy penalty for collision risk
-      cost += 1000.0 * (safety_radius_ - min_obs_dist);
+      cost += 5000.0 * std::pow(safety_radius_ - min_obs_dist, 2) * (1.0 + v);
     } else {
       // Small penalty: encourage keeping clearance
       cost += 1.0 / (min_obs_dist * min_obs_dist);
@@ -142,9 +162,14 @@ double MPPIOptimizer::compute_cost(
     cost += 0.2 / std::max(0.05, v);
   }
 
+  // Encourage smooth motions
+  double delta_v = v - last_v_;
+  double delta_w = w - last_w_;
+  cost += 0.1 * (delta_v * delta_v) + 0.1 * (delta_w * delta_w);
+
   // --- Regularization ---
   // Smooth motions: penalize high linear/angular velocities
-  cost += 0.005 * (v * v) + 0.01 * (w * w);
+  cost += 0.002 * (v * v) + 0.005 * (w * w);
 
   return cost;
 }
@@ -165,20 +190,16 @@ MPPIResult MPPIOptimizer::compute_control(
   double yaw = tf2::getYaw(current_pose.orientation);
 
   // Select goal pose (within horizon, or last path point)
-  const auto & goal_pose = path.poses[std::min(static_cast<size_t>(horizon_steps_),
-      path.poses.size() - 1)].pose;
-  double gx = goal_pose.position.x;
-  double gy = goal_pose.position.y;
+  int last_pose = std::min(static_cast<size_t>(horizon_steps_), path.poses.size() - 1);
+  int sim_steps = std::max(1, last_pose);
+  const auto & path_pose = path.poses[last_pose].pose;
+  double px = path_pose.position.x;
+  double py = path_pose.position.y;
+  double dist_to_goal = std::hypot(px - x, py - y);
 
   // Compute heading error to the goal
-  double angle_to_goal = std::atan2(gy - y, gx - x);
+  double angle_to_goal = std::atan2(py - y, px - x);
   double angle_error = shortest_angular_distance(yaw, angle_to_goal);
-
-  // If not facing the goal, rotate in place to align
-  if (std::abs(angle_error) > fov_ / 2.0) {
-    double w = std::clamp(angle_error, -max_ang_vel_, max_ang_vel_);
-    return MPPIResult{0.0, w, {}, {}};
-  }
 
   // Initialize sampling
   std::vector<TrajectorySample> samples;
@@ -187,23 +208,34 @@ MPPIResult MPPIOptimizer::compute_control(
   std::vector<std::vector<std::pair<double, double>>> all_trajs;
   std::vector<std::pair<double, double>> best_traj;
 
-  // Base velocities: forward motion reduced if misaligned
-  double base_v = 0.6 * std::cos(angle_error);
-  base_v = std::max(0.2, base_v);
-  double base_w = 0.1;
+  // Base velocity proportional to heading
+  double angle_mag = std::abs(angle_error);
+
+  // Scale linear velocity based on angular error
+  double v_scale = 1.0;
+  if (angle_mag > M_PI / 4.0) {          // more than 45°
+    v_scale = 0.2;                       // move slowly
+  } else if (angle_mag > M_PI / 8.0) {   // more than 22.5° and less than 45°
+    v_scale = 0.5;                       // move moderately
+  }
+
+  // Base velocities 
+  // Scale linear velocity based on distance to goal: closer to goal, faster we go 
+  double base_v = max_lin_vel_ * std::min(dist_to_goal, 1.0) * v_scale; 
+  base_v = std::clamp(base_v, 0.0, max_lin_vel_); 
+  
+  // Angular velocity is proportional to the heading error: turn faster if more misaligned 
+  double w_scale = std::min(1.0, 2.0 * angle_mag / M_PI); 
+  double base_w = std::clamp(w_scale * angle_error, -max_ang_vel_, max_ang_vel_); 
 
   // Generate candidate trajectories
   for (int i = 0; i < num_samples_; ++i) {
-    // Sample linear/angular velocities with Gaussian noise
-    double v = std::max(0.0, base_v + normal_(rng_));
-    double w = base_w + normal_(rng_);
-
-    // Clamp velocities to allowed limits
-    v = std::clamp(v, -max_lin_vel_, max_lin_vel_);
-    w = std::clamp(w, -max_ang_vel_, max_ang_vel_);
+    // Sample noise for velocities with Gaussian distribution and clamp
+    double v = std::clamp(base_v + v_noise_(rng_), -max_lin_vel_, max_lin_vel_);
+    double w = std::clamp(base_w + w_noise_(rng_), -max_ang_vel_, max_ang_vel_);
 
     // Simulate trajectory and compute its cost
-    auto traj = simulate_trajectory(x, y, yaw, v, w);
+    auto traj = simulate_trajectory(x, y, yaw, v, w, path, sim_steps);
     double cost = compute_cost(traj, path, v, w, yaw, points);
     all_trajs.push_back(traj);
 
@@ -212,8 +244,12 @@ MPPIResult MPPIOptimizer::compute_control(
   }
 
   // Softmin: Find minimum cost among samples
-  double min_cost = std::min_element(samples.begin(), samples.end(),
-      [](const auto & a, const auto & b) {return a.cost < b.cost;})->cost;
+  auto best_sample_it = std::min_element(samples.begin(), samples.end(),
+      [](const auto & a, const auto & b) {return a.cost < b.cost;});
+
+  // Best trajectory and cost
+  best_traj = all_trajs[std::distance(samples.begin(), best_sample_it)];
+  double min_cost = best_sample_it->cost;
 
   // Adapt lambda (temperature) if velocities collapse to near zero
   double min_v_sample = std::numeric_limits<double>::max();
@@ -221,8 +257,8 @@ MPPIResult MPPIOptimizer::compute_control(
     min_v_sample = std::min(min_v_sample, s.v);
   }
 
-  if (min_v_sample < 0.1) {
-    lambda_ = std::min(8.0, lambda_ * 1.5); // increase lambda if tends to zero (stop)
+  if (min_v_sample < 0.05) {
+    lambda_ = std::min(5.0, lambda_ * 1.2); // increase lambda if tends to zero (stop)
   }
 
   // Softmin weighting of samples
@@ -232,40 +268,28 @@ MPPIResult MPPIOptimizer::compute_control(
     denom += sample.cost;
   }
 
-  // Weighted average of velocities
+ // Weighted average of velocities
   double vlin = 0.0, vrot = 0.0;
   for (const auto & sample : samples) {
     vlin += sample.v * sample.cost / denom;
     vrot += sample.w * sample.cost / denom;
   }
 
-  // Clamp to velocity limits
-  vlin = std::clamp(vlin, -max_lin_vel_, max_lin_vel_);
-  vrot = std::clamp(vrot, -max_ang_vel_, max_ang_vel_);
+  // Calculate the maximum change in velocities based on acceleration limits
+  double max_v_delta = max_lin_acc_ * dt_;
+  double max_w_delta = max_ang_acc_ * dt_;
 
-  // Best trajectory from averaged control
-  best_traj = simulate_trajectory(x, y, yaw, vlin, vrot);
+  // Limit velocity changes (slew rate)
+  vlin = last_v_ + std::clamp(vlin - last_v_, -max_v_delta, max_v_delta);
+  vrot = last_w_ + std::clamp(vrot - last_w_, -max_w_delta, max_w_delta);
 
-  // Obstacle clearance check
-  double clearance = std::numeric_limits<double>::max();
-  for (const auto & p : points) {
-    for (const auto & xy : best_traj) {
-      double dx = p.x - xy.first;
-      double dy = p.y - xy.second;
-      clearance = std::min(clearance, std::hypot(dx, dy));
-    }
-  }
-
-  // If clearance is safe and goal is in FOV, ensure minimum forward speed
-  if (clearance > 0.6 && std::abs(angle_error) < fov_) {
-    vlin = std::max(vlin, 0.2);
-    best_traj = simulate_trajectory(x, y, yaw, vlin, vrot);
-  }
-
-  all_trajs.push_back(best_traj);
+  // Smooth velocities
+  double alpha_smooth = 0.2;  // lower is more smooth
+  last_v_ = alpha_smooth * vlin + (1.0 - alpha_smooth) * last_v_;
+  last_w_ = alpha_smooth * vrot + (1.0 - alpha_smooth) * last_w_;
 
   // Return final control command and trajectories
-  return MPPIResult{vlin, vrot, all_trajs, best_traj};
+  return MPPIResult{last_v_, last_w_, all_trajs, best_traj};
 }
 
 }  // namespace easynav

--- a/easynav_mppi_controller/src/easynav_mppi_controller/MPPIOptimizer.cpp
+++ b/easynav_mppi_controller/src/easynav_mppi_controller/MPPIOptimizer.cpp
@@ -6,14 +6,17 @@
 #include <algorithm>
 #include <iostream>
 
+#include "easynav_common/types/Perceptions.hpp"
+#include "easynav_common/types/PointPerception.hpp"
+
 namespace easynav
 {
 
 MPPIOptimizer::MPPIOptimizer(
   double num_samples, double horizon_steps, double dt, double lambda,
-  double max_lin_vel, double max_ang_vel, double fov)
+  double max_lin_vel, double max_ang_vel, double fov, double safety_radius)
 : num_samples_(num_samples), horizon_steps_(horizon_steps), dt_(dt), lambda_(lambda),
-  max_lin_vel_(max_lin_vel), max_ang_vel_(max_ang_vel), fov_(fov)
+  max_lin_vel_(max_lin_vel), max_ang_vel_(max_ang_vel), fov_(fov), safety_radius_(safety_radius)
 {
 }
 
@@ -53,172 +56,215 @@ double MPPIOptimizer::shortest_angular_distance(double from, double to)
 double MPPIOptimizer::compute_cost(
   const std::vector<std::pair<double, double>> & trajectory,
   const nav_msgs::msg::Path & path,
-  double v, double w,
-  double initial_yaw)
+  double v, double w, double initial_yaw,
+  const pcl::PointCloud<pcl::PointXYZ> & points
+)
 {
-  // Total cost for the trajectory
+  // Total cost accumulator
   double cost = 0.0;
 
-  // --- Penalties ---
+  // --- Path-Tracking Penalties ---
   for (size_t i = 0; i < trajectory.size(); ++i) {
     const auto &[x, y] = trajectory[i];
 
-    // 1. Distance penalty: get the minimum distance to the path
     double min_dist = std::numeric_limits<double>::max();
-    // 2. Heading penalty: how well the trajectory aligns with the path
     double heading_penalty = 0.0;
-    // 3. FOV penalty: how well the trajectory stays within the robot's field of view
     double fov_penalty = 0.0;
 
+    // Distance to path: encourage staying close to planned path
     for (const auto & pose_stamped : path.poses) {
       double dx = pose_stamped.pose.position.x - x;
       double dy = pose_stamped.pose.position.y - y;
       double dist = std::hypot(dx, dy);
       if (dist < min_dist) {
         min_dist = dist;
-
+        // Heading alignment with nearest path point
         heading_penalty = heading_error(
           initial_yaw, pose_stamped.pose.position.x, pose_stamped.pose.position.y, x, y);
       }
     }
 
+    // FOV penalty: discourage trajectories outside robot's view
     double angle_to_target = heading_error(initial_yaw, trajectory.back().first,
         trajectory.back().second, x, y);
     fov_penalty = 0.5 * std::pow(std::max(0.0, angle_to_target - fov_), 2);
 
-    cost += min_dist;                // Distance
-    cost += 0.1 * heading_penalty;   // Heading
-    cost += 0.5 * fov_penalty;       // FOV
+    // Accumulate penalties
+    cost += min_dist;                // distance to path
+    cost += 0.1 * heading_penalty;   // heading misalignment
+    cost += 0.5 * fov_penalty;       // leaving field of view
+  }
+
+  // --- Goal Progress Penalties ---
+  const auto & goal_pose = path.poses.back().pose;
+  const double gx = goal_pose.position.x;
+  const double gy = goal_pose.position.y;
+
+  const auto & start_xy = trajectory.front();
+  const auto & end_xy = trajectory.back();
+
+  double d_start_goal = std::hypot(gx - start_xy.first, gy - start_xy.second);
+  double d_end_goal = std::hypot(gx - end_xy.first, gy - end_xy.second);
+
+  // how much closer we got to goal
+  double progress = d_start_goal - d_end_goal;
+
+  cost += -2.0 * progress;   // reward moving closer to goal
+  cost += 1.5 * d_end_goal;  // penalize being far from goal at end
+
+
+  // --- Obstacle Avoidance Penalties ---
+  double min_obs_overall = std::numeric_limits<double>::max();
+
+  for (const auto & point : points) {
+    double min_obs_dist = std::numeric_limits<double>::max();
+    for (const auto &[x, y] : trajectory) {
+      double dx = point.x - x;
+      double dy = point.y - y;
+      double dist = std::hypot(dx, dy);
+      if (dist < min_obs_dist) {min_obs_dist = dist;}
+    }
+    min_obs_overall = std::min(min_obs_overall, min_obs_dist);
+
+    // Safety margin (robot radius + margin)
+    if (min_obs_dist < safety_radius_) {
+      // Heavy penalty for collision risk
+      cost += 1000.0 * (safety_radius_ - min_obs_dist);
+    } else {
+      // Small penalty: encourage keeping clearance
+      cost += 1.0 / (min_obs_dist * min_obs_dist);
+    }
+  }
+
+  // --- Velocity Encouragement ---
+  // If obstacles are far, discourage staying too slow
+  if (min_obs_overall > 0.6) {
+    cost += 0.2 / std::max(0.05, v);
   }
 
   // --- Regularization ---
-  // Penalize high speeds to avoid sudden accelerations
-  // and keep the robot within a reasonable speed range
-  // This helps prevent abrupt movements and improves the robot's stability
-  cost += 0.002 * (v * v + w * w);
+  // Smooth motions: penalize high linear/angular velocities
+  cost += 0.005 * (v * v) + 0.01 * (w * w);
 
   return cost;
 }
 
 MPPIResult MPPIOptimizer::compute_control(
   const geometry_msgs::msg::Pose & current_pose,
-  const nav_msgs::msg::Path & path)
+  const nav_msgs::msg::Path & path,
+  const pcl::PointCloud<pcl::PointXYZ> & points)
 {
+  // If the path is empty, stop the robot
   if (path.poses.empty()) {
     return MPPIResult{0.0, 0.0, {}, {}};
   }
 
-  // Initial conditions
+  // Current robot state
   double x = current_pose.position.x;
   double y = current_pose.position.y;
   double yaw = tf2::getYaw(current_pose.orientation);
 
-  // Compute the angle to the goal pose based on the horizon steps
-  // If horizon_steps_ is larger than the path size, use the last pose
-  // This ensures that we always have a valid goal pose to align with
+  // Select goal pose (within horizon, or last path point)
   const auto & goal_pose = path.poses[std::min(static_cast<size_t>(horizon_steps_),
       path.poses.size() - 1)].pose;
   double gx = goal_pose.position.x;
   double gy = goal_pose.position.y;
+
+  // Compute heading error to the goal
   double angle_to_goal = std::atan2(gy - y, gx - x);
   double angle_error = shortest_angular_distance(yaw, angle_to_goal);
 
-  // Check if the robot is aligned with the goal
+  // If not facing the goal, rotate in place to align
   if (std::abs(angle_error) > fov_ / 2.0) {
-    // Rotate to align with the goal
     double w = std::clamp(angle_error, -max_ang_vel_, max_ang_vel_);
     return MPPIResult{0.0, w, {}, {}};
   }
 
-  // If aligned, proceed with MPPI sampling
+  // Initialize sampling
   std::vector<TrajectorySample> samples;
   samples.reserve(static_cast<size_t>(num_samples_));
 
   std::vector<std::vector<std::pair<double, double>>> all_trajs;
   std::vector<std::pair<double, double>> best_traj;
-  double best_cost = std::numeric_limits<double>::max();
 
-  // Base velocity and angular velocity
-  double base_v = 0.6;
+  // Base velocities: forward motion reduced if misaligned
+  double base_v = 0.6 * std::cos(angle_error);
+  base_v = std::max(0.2, base_v);
   double base_w = 0.1;
 
-  // Generate samples
+  // Generate candidate trajectories
   for (int i = 0; i < num_samples_; ++i) {
-    // Add Gaussian noise to the base velocities
+    // Sample linear/angular velocities with Gaussian noise
     double v = std::max(0.0, base_v + normal_(rng_));
-    // Add Gaussian noise to the base angular velocities
     double w = base_w + normal_(rng_);
 
-    // Ensure velocities are within limits
-    // Clamp linear velocity to max_lin_vel_ and angular velocity to max_ang_vel_
+    // Clamp velocities to allowed limits
     v = std::clamp(v, -max_lin_vel_, max_lin_vel_);
     w = std::clamp(w, -max_ang_vel_, max_ang_vel_);
 
-    // Simulate the trajectory with the given velocities
+    // Simulate trajectory and compute its cost
     auto traj = simulate_trajectory(x, y, yaw, v, w);
+    double cost = compute_cost(traj, path, v, w, yaw, points);
     all_trajs.push_back(traj);
-
-    // Compute the cost of the trajectory
-    double cost = compute_cost(traj, path, v, w, yaw);
-
-    // Update the best trajectory
-    if (cost < best_cost) {
-      best_cost = cost;
-      best_traj = traj;
-    }
 
     // Store the sample with its cost
     samples.push_back({v, w, cost});
   }
 
-  // Sort samples by cost: Softmin
+  // Softmin: Find minimum cost among samples
   double min_cost = std::min_element(samples.begin(), samples.end(),
       [](const auto & a, const auto & b) {return a.cost < b.cost;})->cost;
 
-  // Compute the mean and variance of the costs
-  double mean_cost = 0.0;
+  // Adapt lambda (temperature) if velocities collapse to near zero
+  double min_v_sample = std::numeric_limits<double>::max();
   for (const auto & s : samples) {
-    mean_cost += s.cost;
+    min_v_sample = std::min(min_v_sample, s.v);
   }
-  mean_cost /= samples.size();
 
-  double var_cost = 0.0;
-  for (const auto & s : samples) {
-    var_cost += std::pow(s.cost - mean_cost, 2);
+  if (min_v_sample < 0.1) {
+    lambda_ = std::min(8.0, lambda_ * 1.5); // increase lambda if tends to zero (stop)
   }
-  var_cost /= samples.size();
 
-  // Compute lambda dynamically based on the variance of the costs
-  // This allows the algorithm to adapt to the variability of the costs
-  // and adjust the exploration-exploitation trade-off
-  lambda_ = std::clamp(var_cost, 1.0, 5.0);
-
-  // Normalize the costs
+  // Softmin weighting of samples
   double denom = 0.0;
   for (auto & sample : samples) {
     sample.cost = std::exp(-1.0 / lambda_ * (sample.cost - min_cost));
     denom += sample.cost;
   }
 
-  // Compute the average linear and angular velocities based on the normalized costs
-  // This step combines the samples into a single control command
-  // weighted by their costs, allowing the algorithm to focus on the most promising trajectories
-  double vlin = 0.0;
-  double vrot = 0.0;
+  // Weighted average of velocities
+  double vlin = 0.0, vrot = 0.0;
   for (const auto & sample : samples) {
     vlin += sample.v * sample.cost / denom;
     vrot += sample.w * sample.cost / denom;
   }
 
-  // Ensure velocities are within limits
+  // Clamp to velocity limits
   vlin = std::clamp(vlin, -max_lin_vel_, max_lin_vel_);
   vrot = std::clamp(vrot, -max_ang_vel_, max_ang_vel_);
 
-  // Predict the trajectory based on the velocities
+  // Best trajectory from averaged control
   best_traj = simulate_trajectory(x, y, yaw, vlin, vrot);
+
+  // Obstacle clearance check
+  double clearance = std::numeric_limits<double>::max();
+  for (const auto & p : points) {
+    for (const auto & xy : best_traj) {
+      double dx = p.x - xy.first;
+      double dy = p.y - xy.second;
+      clearance = std::min(clearance, std::hypot(dx, dy));
+    }
+  }
+
+  // If clearance is safe and goal is in FOV, ensure minimum forward speed
+  if (clearance > 0.6 && std::abs(angle_error) < fov_) {
+    vlin = std::max(vlin, 0.2);
+    best_traj = simulate_trajectory(x, y, yaw, vlin, vrot);
+  }
+
   all_trajs.push_back(best_traj);
 
-  // Return the control command
+  // Return final control command and trajectories
   return MPPIResult{vlin, vrot, all_trajs, best_traj};
 }
 


### PR DESCRIPTION
Changes and Improvements:
- Improved cost computation for the initial MPPI controller.
- Added a new cost term based on available perception data.
- Added new parameters to the YAML file to support the controller.

Launch Configuration:
- To use this controller with EasyNav, include the following in your YAML parameter file:
```bash
controller_node:
  ros__parameters:
    use_sim_time: true
    controller_types: [mppi]
    mppi:
      rt_freq: 30.0 
      plugin: easynav_mppi_controller/MPPIController
      num_samples: 200
      horizon_steps: 20
      dt: 0.15
      lambda: 0.8
      max_linear_velocity: 1.0
      max_angular_velocity: 1.0
      fov: 1.57
      safety_radius: 0.6
```