### PR TITLE
Refactoring simple controller and jazzy badges in Serest and MPPI

### DIFF
--- a/controllers/easynav_mppi_controller/README.md
+++ b/controllers/easynav_mppi_controller/README.md
@@ -1,6 +1,7 @@
 # easynav_mppi_controller
 
-[![ROS 2: kilted](https://img.shields.io/badge/ROS%202-kilted-blue)](#) [![ROS 2: rolling](https://img.shields.io/badge/ROS%202-rolling-blue)](#)
+[![ROS 2: kilted](https://img.shields.io/badge/ROS%202-kilted-blue)](#) [![ROS 2: rolling](https://img.shields.io/badge/ROS%202-rolling-blue)](#) [![ROS 2: jazzy](https://img.shields.io/badge/ROS%202-jazzy-blue)](#)
+
 
 ## Description
 A Model Predictive Path Integral (MPPI) controller implementation for Easy Navigation.
@@ -14,6 +15,7 @@ A Model Predictive Path Integral (MPPI) controller implementation for Easy Navig
 |---|---|
 | kilted | ![kilted](https://img.shields.io/badge/kilted-supported-brightgreen) |
 | rolling | ![rolling](https://img.shields.io/badge/rolling-supported-brightgreen) |
+| jazzy | ![jazzy](https://img.shields.io/badge/jazzy-supported-brightgreen) |
 
 ## Plugin (pluginlib)
 - **Plugin Name:** `easynav_mppi_controller/MPPIController`

--- a/controllers/easynav_serest_controller/README.md
+++ b/controllers/easynav_serest_controller/README.md
@@ -1,6 +1,7 @@
 # easynav_serest_controller
 
-[![ROS 2: kilted](https://img.shields.io/badge/ROS%202-kilted-blue)](#) [![ROS 2: rolling](https://img.shields.io/badge/ROS%202-rolling-blue)](#)
+[![ROS 2: kilted](https://img.shields.io/badge/ROS%202-kilted-blue)](#) [![ROS 2: rolling](https://img.shields.io/badge/ROS%202-rolling-blue)](#) [![ROS 2: jazzy](https://img.shields.io/badge/ROS%202-jazzy-blue)](#)
+
 
 ## Description
 A SeReST (Smooth Error-Responsive Speed and Turning) controller for path tracking.
@@ -11,9 +12,10 @@ A SeReST (Smooth Error-Responsive Speed and Turning) controller for path trackin
 
 ## Supported ROS 2 Distributions
 | Distribution | Status |
-|---|---|
+|---|---:|
 | kilted | ![kilted](https://img.shields.io/badge/kilted-supported-brightgreen) |
-| rolling | ![rolling](https://img.shields.io/badge/rolling-supported-brightgreen) |
+| rolling | ![rolling](https://img.shields.io/badge/rolling-supported-brightgreen) | 
+| jazzy | ![jazzy](https://img.shields.io/badge/jazzy-supported-brightgreen) |
 
 ## Plugin (pluginlib)
 - **Plugin Name:** `easynav_serest_controller/SerestController`

--- a/controllers/easynav_simple_controller/README.md
+++ b/controllers/easynav_simple_controller/README.md
@@ -1,62 +1,65 @@
-# easynav_vff_controller
+# easynav_simple_controller
 
-[![ROS 2: kilted](https://img.shields.io/badge/ROS%202-kilted-blue)](#) [![ROS 2: rolling](https://img.shields.io/badge/ROS%202-rolling-blue)](#)
+[![ROS 2: kilted](https://img.shields.io/badge/ROS%202-kilted-blue)](#) [![ROS 2: rolling](https://img.shields.io/badge/ROS%202-rolling-blue)](#) [![ROS 2: jazzy](https://img.shields.io/badge/ROS%202-jazzy-blue)](#)
 
 ## Description
-Vector Field Histogram (VFF) controller for obstacle avoidance and goal tracking.  
-Implements a reactive navigation approach that computes motion commands based on the vector sum of attractive and repulsive forces derived from goal and obstacle information.
+Simple path-following controller that uses PID controllers and a look-ahead reference pose to follow a planned path. It produces velocity commands (`cmd_vel`) based on the reference pose sampled at a look-ahead distance and limits linear/angular speeds and accelerations.
 
 ## Authors and Maintainers
 - **Authors:** Intelligent Robotics Lab  
-- **Maintainers:** Jose Miguel Guerrero Hernández <josemiguel.guerrero@urjc.es>
+- **Maintainers:** Francisco Martín Rico <fmrico@gmail.com>
 
 ## Supported ROS 2 Distributions
 | Distribution | Status |
-|---|---|
+|---|---:|
 | kilted | ![kilted](https://img.shields.io/badge/kilted-supported-brightgreen) |
-| rolling | ![rolling](https://img.shields.io/badge/rolling-supported-brightgreen) |
+| rolling | ![rolling](https://img.shields.io/badge/rolling-supported-brightgreen) | 
+| jazzy | ![jazzy](https://img.shields.io/badge/jazzy-supported-brightgreen) |
 
 ## Plugin (pluginlib)
-- **Plugin Name:** `easynav_vff_controller/VffController`  
-- **Type:** `easynav::VffController`  
-- **Base Class:** `easynav::ControllerMethodBase`  
-- **Library:** `vff_controller`  
-- **Description:** Reactive controller that generates velocity commands using the Vector Field Histogram method.
+- **Plugin Name:** `easynav_simple_controller/SimpleController`
+- **Type:** `easynav::SimpleController`
+- **Base Class:** `easynav::ControllerMethodBase`
+- **Library:** `easynav_simple_controller`
+- **Description:** Path-following controller using PID (linear and angular) and a look-ahead strategy.
 
 ## Parameters
-All parameters are declared under the plugin namespace, i.e., `/<node_fqn>/easynav_vff_controller/VffController/...`.
+All parameters are declared under the plugin namespace, i.e., `/<node_fqn>/easynav_simple_controller/SimpleController/...`.
 
 | Name | Type | Default | Description |
 |---|---|---:|---|
-| `<plugin>.distance_obstacle_detection` | `float` | `3.0` | Distance threshold for obstacle detection. |
-| `<plugin>.distance_to_goal` | `float` | `1.0` | Minimum distance to consider the goal reached. |
-| `<plugin>.obstacle_detection_x_min` | `float` | `0.5` | Minimum X limit for obstacle detection (m). |
-| `<plugin>.obstacle_detection_x_max` | `float` | `10.0` | Maximum X limit for obstacle detection (m). |
-| `<plugin>.obstacle_detection_y_min` | `float` | `-10.0` | Minimum Y limit for obstacle detection (m). |
-| `<plugin>.obstacle_detection_y_max` | `float` | `10.0` | Maximum Y limit for obstacle detection (m). |
-| `<plugin>.obstacle_detection_z_min` | `float` | `0.10` | Minimum Z limit for obstacle detection (m). |
-| `<plugin>.obstacle_detection_z_max` | `float` | `1.00` | Maximum Z limit for obstacle detection (m). |
-| `<plugin>.max_speed` | `double` | `0.8` | Maximum linear velocity (m/s). |
-| `<plugin>.max_angular_speed` | `double` | `1.5` | Maximum angular velocity (rad/s). |
+| `max_linear_speed` | `double` | `1.0` | Maximum linear speed (m/s).
+| `max_angular_speed` | `double` | `1.0` | Maximum angular speed (rad/s).
+| `max_linear_acc` | `double` | `0.3` | Maximum linear acceleration (m/s²).
+| `max_angular_acc` | `double` | `0.3` | Maximum angular acceleration (rad/s²).
+| `look_ahead_dist` | `double` | `1.0` | Look-ahead distance to sample the reference pose on the path (m).
+| `tolerance_dist` | `double` | `0.05` | Distance threshold to switch to pure orientation tracking (m).
+| `final_goal_angle_tolerance` | `double` | `0.1` | Angular tolerance (rad) used to decide final-goal arrival.
+| `k_rot` | `double` | `0.5` | Gain used to reduce linear speed based on angular velocity (higher: stronger reduction while turning).
+| `linear_kp` | `double` | `0.95` | Proportional gain for the linear PID controller.
+| `linear_ki` | `double` | `0.03` | Integral gain for the linear PID controller.
+| `linear_kd` | `double` | `0.08` | Derivative gain for the linear PID controller.
+| `angular_kp` | `double` | `1.5` | Proportional gain for the angular PID controller.
+| `angular_ki` | `double` | `0.03` | Integral gain for the angular PID controller.
+| `angular_kd` | `double` | `0.08` | Derivative gain for the angular PID controller.
 
-## Interfaces (Topics and Services)
+## Interfaces (NavState, Topics and Services)
 
-### Subscriptions and Publications
-This controller communicates exclusively through `NavState`; it does not create direct ROS 2 publishers or subscribers.
+### NavState
+This controller uses the shared `NavState` bag provided by the `easynav_core` framework. The following keys are used at runtime by `SimpleController`:
 
-### Services
-This package does not create service servers or clients.
-
-## NavState Keys
 | Key | Type | Access | Notes |
 |---|---|---|---|
-| `goals` | `nav_msgs::msg::Goals` | **Read** | Target goals to reach. |
-| `robot_pose` | `nav_msgs::msg::Odometry` | **Read** | Current robot pose used to compute forces. |
-| `points` | `PointPerceptions` | **Read** | Point cloud of obstacles. |
-| `cmd_vel` | `geometry_msgs::msg::TwistStamped` | **Write** | Output velocity command computed by VFF. |
+| `robot_pose` | `nav_msgs::msg::Odometry` | **Read** | Current robot odometry used to compute the robot pose and yaw.
+| `path` | `nav_msgs::msg::Path` | **Read** | Planned path to follow. The controller samples a reference pose at `look_ahead_dist` along this path.
+| `cmd_vel` | `geometry_msgs::msg::TwistStamped` | **Write** | Output velocity command. Header.frame_id is set to `path.header.frame_id` when available and stamp to the controller node clock.
+
+### Topics / Services
+The controller itself does not create ROS publishers/subscribers or service servers. It interacts via the `NavState` abstraction; how `NavState` is exposed (topics or other IPC mechanisms) depends on the integrating node.
+
 
 ## TF Frames
-This controller reads pose from `nav_msgs/Odometry` (`robot_pose` key). No TF lookups are performed.
+This controller reads pose from `nav_msgs/Odometry` (NavState key `robot_pose`). TF is not directly used in this plugin.
 
 ## License
 GPL-3.0-only

--- a/controllers/easynav_simple_controller/include/easynav_simple_controller/PIDController.hpp
+++ b/controllers/easynav_simple_controller/include/easynav_simple_controller/PIDController.hpp
@@ -51,12 +51,18 @@ public:
   /**
    * @brief Computes the control output for the given reference input.
    *
-   * Applies the PID formula and returns the control command within the specified output limits.
-   *
-   * @param new_reference The current reference input value (e.g., error signal).
-   * @return The computed control output.
+  * Applies the PID formula and returns the control command within the specified output limits.
+  *
+  * @param new_reference The current reference input value (e.g., error signal).
+  * @param dt Time elapsed since last call in seconds.
+  * @return The computed control output.
    */
-  double get_output(double new_reference);
+  double get_output(double new_reference, double dt);
+
+  /**
+  * @brief Reset internal integrator and derivative state.
+  */
+  void reset();
 
 private:
   double KP_;               ///< Proportional gain.
@@ -70,6 +76,7 @@ private:
 
   double prev_error_;       ///< Previous error value (for derivative term).
   double int_error_;        ///< Accumulated integral error.
+  double integral_limit_ {0.0}; ///< If >0, clamps the integral term to ±integral_limit_.
 };
 
 }  // namespace easynav

--- a/controllers/easynav_simple_controller/include/easynav_simple_controller/SimpleController.hpp
+++ b/controllers/easynav_simple_controller/include/easynav_simple_controller/SimpleController.hpp
@@ -50,7 +50,14 @@ protected:
   double max_angular_acc_{0.3};    ///< Maximum angular acceleration in rad/s².
   double look_ahead_dist_{1.0};    ///< Distance ahead of the robot to track in meters.
   double tolerance_dist_{0.05};    ///< Distance threshold to switch to orientation tracking.
-  double k_rot_{0.5};
+  double k_rot_{0.5};              ///< Gain to reduce linear speed based on angular velocity.
+  double final_goal_angle_tolerance_{0.1};  ///< Angular tolerance at the final goal in radians.
+  double linear_kp_{0.95};         ///< Proportional gain for linear PID.
+  double linear_ki_{0.03};         ///< Integral gain for linear PID.
+  double linear_kd_{0.08};         ///< Derivative gain for linear PID.
+  double angular_kp_{1.5};        ///< Proportional gain for angular PID.
+  double angular_ki_{0.03};        ///< Integral gain for angular PID.
+  double angular_kd_{0.08};        ///< Derivative gain for angular PID.
 
   double last_vlin_{0.0};          ///< Previous linear velocity for acceleration limiting.
   double last_vrot_{0.0};          ///< Previous angular velocity for acceleration limiting.

--- a/controllers/easynav_simple_controller/src/easynav_simple_controller/PIDController.cpp
+++ b/controllers/easynav_simple_controller/src/easynav_simple_controller/PIDController.cpp
@@ -27,9 +27,10 @@ PIDController::PIDController(double min_ref, double max_ref, double min_output, 
   max_output_ = max_output;
   prev_error_ = int_error_ = 0.0;
 
-  KP_ = 0.70;
-  KI_ = 0.15;
-  KD_ = 0.15;
+  KP_ = 0.7;
+  KI_ = 0.0; // start with no integral to avoid windup
+  KD_ = 0.0;
+  integral_limit_ = max_output_ * 2.0; // default integral clamp
 }
 
 void
@@ -41,35 +42,51 @@ PIDController::set_pid(double n_KP, double n_KI, double n_KD)
 }
 
 double
-PIDController::get_output(double new_reference)
+PIDController::get_output(double new_reference, double dt)
 {
-  double ref = new_reference;
-  double output = 0.0;
-
-  // Proportional Error
-  double direction = 0.0;
-  if (ref != 0.0) {
-    direction = ref / fabs(ref);
+  if (dt <= 0.0) {
+    return 0.0;
   }
 
-  if (fabs(ref) < min_ref_) {
-    output = 0.0;
-  } else if (fabs(ref) > max_ref_) {
-    output = direction * max_output_;
-  } else {
-    output = direction * min_output_ + ref * (max_output_ - min_output_);
+  double error = new_reference;
+
+  // ignore very small errors
+  if (std::fabs(error) < min_ref_) {
+    // decay integrator slightly
+    int_error_ *= 0.9;
+    prev_error_ = error;
+    return 0.0;
   }
 
-  // Integral Error
-  int_error_ = (int_error_ + output) * 2.0 / 3.0;
+  // Proportional term
+  double p = KP_ * error;
 
-  // Derivative Error
-  double deriv_error = output - prev_error_;
-  prev_error_ = output;
+  // Integral term with anti-windup
+  int_error_ += error * dt;
+  if (integral_limit_ > 0.0) {
+    if (int_error_ * KI_ > integral_limit_) {int_error_ = integral_limit_ / KI_;}
+    if (int_error_ * KI_ < -integral_limit_) {int_error_ = -integral_limit_ / KI_;}
+  }
+  double i = KI_ * int_error_;
 
-  output = KP_ * output + KI_ * int_error_ + KD_ * deriv_error;
+  // Derivative term
+  double deriv = (error - prev_error_) / dt;
+  double d = KD_ * deriv;
+  prev_error_ = error;
 
-  return std::clamp(output, -max_output_, max_output_);
+  double output = p + i + d;
+
+  // Saturate output to configured limits
+  output = std::clamp(output, -max_output_, max_output_);
+
+  return output;
+}
+
+void
+PIDController::reset()
+{
+  prev_error_ = 0.0;
+  int_error_ = 0.0;
 }
 
 }  // namespace easynav

--- a/controllers/easynav_simple_controller/src/easynav_simple_controller/SimpleController.cpp
+++ b/controllers/easynav_simple_controller/src/easynav_simple_controller/SimpleController.cpp
@@ -51,6 +51,14 @@ SimpleController::on_initialize()
   node->declare_parameter<double>(plugin_name + ".look_ahead_dist", look_ahead_dist_);
   node->declare_parameter<double>(plugin_name + ".tolerance_dist", tolerance_dist_);
   node->declare_parameter<double>(plugin_name + ".k_rot", k_rot_);
+  node->declare_parameter<double>(plugin_name + ".final_goal_angle_tolerance",
+      final_goal_angle_tolerance_);
+  node->declare_parameter<double>(plugin_name + ".linear_kp", linear_kp_);
+  node->declare_parameter<double>(plugin_name + ".linear_ki", linear_ki_);
+  node->declare_parameter<double>(plugin_name + ".linear_kd", linear_kd_);
+  node->declare_parameter<double>(plugin_name + ".angular_kp", angular_kp_);
+  node->declare_parameter<double>(plugin_name + ".angular_ki", angular_ki_);
+  node->declare_parameter<double>(plugin_name + ".angular_kd", angular_kd_);
 
   node->get_parameter<double>(plugin_name + ".max_linear_speed", max_linear_speed_);
   node->get_parameter<double>(plugin_name + ".max_angular_speed", max_angular_speed_);
@@ -59,9 +67,21 @@ SimpleController::on_initialize()
   node->get_parameter<double>(plugin_name + ".look_ahead_dist", look_ahead_dist_);
   node->get_parameter<double>(plugin_name + ".tolerance_dist", tolerance_dist_);
   node->get_parameter<double>(plugin_name + ".k_rot", k_rot_);
+  node->get_parameter<double>(plugin_name + ".final_goal_angle_tolerance",
+      final_goal_angle_tolerance_);
+  node->get_parameter<double>(plugin_name + ".linear_kp", linear_kp_);
+  node->get_parameter<double>(plugin_name + ".linear_ki", linear_ki_);
+  node->get_parameter<double>(plugin_name + ".linear_kd", linear_kd_);
+  node->get_parameter<double>(plugin_name + ".angular_kp", angular_kp_);
+  node->get_parameter<double>(plugin_name + ".angular_ki", angular_ki_);
+  node->get_parameter<double>(plugin_name + ".angular_kd", angular_kd_);
 
   linear_pid_ = std::make_shared<PIDController>(0.01, look_ahead_dist_, 0.1, max_linear_speed_);
   angular_pid_ = std::make_shared<PIDController>(0.01, M_PI, 0.1, max_angular_speed_);
+
+  // apply configured gains
+  linear_pid_->set_pid(linear_kp_, linear_ki_, linear_kd_);
+  angular_pid_->set_pid(angular_kp_, angular_ki_, angular_kd_);
 
   last_vlin_ = 0.0;
   last_vrot_ = 0.0;
@@ -79,7 +99,6 @@ SimpleController::update_rt(NavState & nav_state)
 
   if (!nav_state.has("path")) {return;}
   if (!nav_state.has("robot_pose")) {return;}
-  if (!nav_state.has("path")) {return;}
 
   const auto path = nav_state.get<nav_msgs::msg::Path>("path");
 
@@ -88,13 +107,38 @@ SimpleController::update_rt(NavState & nav_state)
     twist_stamped_.header.stamp = get_node()->now();
     twist_stamped_.twist.linear.x = 0.0;
     twist_stamped_.twist.angular.z = 0.0;
+    // reset PID state when there's no path
+    if (linear_pid_) {linear_pid_->reset();}
+    if (angular_pid_) {angular_pid_->reset();}
     nav_state.set("cmd_vel", twist_stamped_);
     return;
   }
 
-  auto ref_pose = get_ref_pose(path, look_ahead_dist_);
+  // If we're very close to the final path pose, stop the robot.
   const auto pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
+  const auto & goal_pose = path.poses.back().pose;
+  double dist_to_goal = get_distance(pose, goal_pose);
+  double angle_to_goal = get_diff_angle(pose.orientation, goal_pose.orientation);
 
+  if (dist_to_goal <= tolerance_dist_ && std::abs(angle_to_goal) <= final_goal_angle_tolerance_) {
+    // we're at the final goal -> publish zero velocity and reset integrators/state
+    last_vlin_ = 0.0;
+    last_vrot_ = 0.0;
+    twist_stamped_.header.frame_id = path.header.frame_id;
+    twist_stamped_.header.stamp = get_node()->now();
+    twist_stamped_.twist.linear.x = 0.0;
+    twist_stamped_.twist.angular.z = 0.0;
+    // reset PID internal state to avoid windup / residual derivative
+    if (linear_pid_) {linear_pid_->reset();}
+    if (angular_pid_) {angular_pid_->reset();}
+    nav_state.set("cmd_vel", twist_stamped_);
+    RCLCPP_DEBUG(get_node()->get_logger(),
+        "%s: final goal reached (dist=%.3f, ang=%.3f), stopping.",
+        get_plugin_name().c_str(), dist_to_goal, angle_to_goal);
+    return;
+  }
+
+  auto ref_pose = get_ref_pose(path, look_ahead_dist_);
   double dist = get_distance(pose, ref_pose);
 
 
@@ -108,10 +152,10 @@ SimpleController::update_rt(NavState & nav_state)
 
   if (dist < tolerance_dist_) {
     double diff_angle = get_diff_angle(pose.orientation, ref_pose.orientation);
-    vrot = angular_pid_->get_output(diff_angle);
+    vrot = angular_pid_->get_output(diff_angle, dt);
   } else {
-    vrot = angular_pid_->get_output(angle);
-    vlin = std::max(0.0, linear_pid_->get_output(dist) - k_rot_ * abs(vrot));
+    vrot = angular_pid_->get_output(angle, dt);
+    vlin = std::max(0.0, linear_pid_->get_output(dist, dt) - k_rot_ * abs(vrot));
   }
 
 


### PR DESCRIPTION
Hi,

I've added badges for Serest, MPPI, and Simple controllers, as they’ve all been tested in Jazzy. I also updated the Simple controller to allow tuning of PID gains and improved the derivative and integral logic by incorporating a differential time component and a reset function for the integrative and global error terms. Additionally, I introduced an angle threshold to stop the robot once it reaches the goal pose.

These changes have been tested in the easynav_playground_kobuki with the following parameters:
```
controller_node:
  ros__parameters:
    use_sim_time: true
    controller_types: [simple]
    simple:
      rt_freq: 30.0
      plugin: easynav_simple_controller/SimpleController
      max_linear_speed: 1.0
      max_angular_speed: 1.0
      look_ahead_dist: 0.3
      k_rot: 0.3
      final_goal_angle_tolerance: 0.05
      linear_kp: 0.95
      linear_ki: 0.03
      linear_kd: 0.08
      angular_kp: 2.1
      angular_ki: 0.03
      angular_kd: 0.09

```

With this, the controller is more flexible and allows a stronger action on the angular component.

Best,
Esther