### PR TITLE
Optimize execution

### DIFF
--- a/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
+++ b/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
@@ -144,7 +144,7 @@ MPPIController::update_rt(NavState & nav_state)
     return;
   }
 
-  const auto path = nav_state.get<nav_msgs::msg::Path>("path");
+  const auto & path = nav_state.get<nav_msgs::msg::Path>("path");
 
   if (path.poses.empty()) {
     // If the path is empty, stop the robot and clear markers
@@ -164,8 +164,8 @@ MPPIController::update_rt(NavState & nav_state)
     return;
   }
 
-  const auto pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
-  const auto perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
+  const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .filter({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0})

--- a/controllers/easynav_serest_controller/CMakeLists.txt
+++ b/controllers/easynav_serest_controller/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(easynav_core REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 
 
@@ -29,6 +31,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   easynav_common::easynav_common
   easynav_core::easynav_core
   tf2_ros::tf2_ros
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
   pluginlib::pluginlib
   ${geometry_msgs_TARGETS}
   ${nav_msgs_TARGETS}
@@ -68,6 +72,8 @@ ament_export_dependencies(
   easynav_core
   pluginlib
   tf2_ros
+  tf2
+  tf2_geometry_msgs
   geometry_msgs
   nav_msgs
 )

--- a/controllers/easynav_serest_controller/package.xml
+++ b/controllers/easynav_serest_controller/package.xml
@@ -12,6 +12,8 @@
   <depend>easynav_common</depend>
   <depend>easynav_core</depend>
   <depend>pluginlib</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
+++ b/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 
 #include "tf2/utils.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "easynav_common/types/PointPerception.hpp"
 

--- a/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
+++ b/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
@@ -301,7 +301,7 @@ SerestController::closest_obstacle_distance(
   // 2) Analizar los sensores de distancia
   if (!nav_state.has("points")) {return std::numeric_limits<double>::infinity();}
 
-  const auto perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & perceptions = nav_state.get<PointPerceptions>("points");
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(0.3)
     .fuse(get_tf_prefix() + "base_link")

--- a/controllers/easynav_simple_controller/CMakeLists.txt
+++ b/controllers/easynav_simple_controller/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(easynav_core REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 
 
@@ -30,6 +32,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   easynav_common::easynav_common
   easynav_core::easynav_core
   tf2_ros::tf2_ros
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
   pluginlib::pluginlib
   ${geometry_msgs_TARGETS}
   ${nav_msgs_TARGETS}
@@ -70,6 +74,8 @@ ament_export_dependencies(
   easynav_core
   pluginlib
   tf2_ros
+  tf2
+  tf2_geometry_msgs
   geometry_msgs
   nav_msgs
 )

--- a/controllers/easynav_simple_controller/package.xml
+++ b/controllers/easynav_simple_controller/package.xml
@@ -12,6 +12,8 @@
   <depend>easynav_common</depend>
   <depend>easynav_core</depend>
   <depend>pluginlib</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/controllers/easynav_simple_controller/src/easynav_simple_controller/SimpleController.cpp
+++ b/controllers/easynav_simple_controller/src/easynav_simple_controller/SimpleController.cpp
@@ -23,6 +23,7 @@
 #include <expected>
 
 #include "tf2/utils.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "easynav_simple_controller/SimpleController.hpp"
 
@@ -100,7 +101,7 @@ SimpleController::update_rt(NavState & nav_state)
   if (!nav_state.has("path")) {return;}
   if (!nav_state.has("robot_pose")) {return;}
 
-  const auto path = nav_state.get<nav_msgs::msg::Path>("path");
+  const auto & path = nav_state.get<nav_msgs::msg::Path>("path");
 
   if (path.poses.empty()) {
     twist_stamped_.header.frame_id = path.header.frame_id;
@@ -115,7 +116,7 @@ SimpleController::update_rt(NavState & nav_state)
   }
 
   // If we're very close to the final path pose, stop the robot.
-  const auto pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
+  const auto & pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
   const auto & goal_pose = path.poses.back().pose;
   double dist_to_goal = get_distance(pose, goal_pose);
   double angle_to_goal = get_diff_angle(pose.orientation, goal_pose.orientation);

--- a/controllers/easynav_vff_controller/src/easynav_vff_controller/VffController.cpp
+++ b/controllers/easynav_vff_controller/src/easynav_vff_controller/VffController.cpp
@@ -257,7 +257,7 @@ void VffController::update_rt(NavState & nav_state)
     // Calculate the angle error
     double angle_error = normalize_angle(bearing - yaw);
 
-    const auto perceptions = nav_state.get<PointPerceptions>("points");
+    const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
     auto fused =
       PointPerceptionsOpsView(perceptions)

--- a/localizers/easynav_costmap_localizer/include/easynav_costmap_localizer/AMCLLocalizer.hpp
+++ b/localizers/easynav_costmap_localizer/include/easynav_costmap_localizer/AMCLLocalizer.hpp
@@ -187,7 +187,7 @@ protected:
   std::vector<Particle> particles_;
 
   /// Random number generator used for sampling noise.
-  std::default_random_engine rng_;
+  std::mt19937 rng_;
 
   /// Current estimated odometry-based pose.
   nav_msgs::msg::Odometry pose_;

--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -161,6 +161,7 @@ using namespace std::chrono_literals;
 
 
 AMCLLocalizer::AMCLLocalizer()
+: rng_(std::random_device{}())
 {
   NavState::register_printer<nav_msgs::msg::Odometry>(
     [](const nav_msgs::msg::Odometry & odom) {
@@ -527,8 +528,6 @@ AMCLLocalizer::predict([[maybe_unused]] NavState & nav_state)
   tf2::Matrix3x3(delta.getRotation()).getRPY(roll, pitch, yaw);
   double rot_len = std::abs(yaw);
 
-  std::random_device rd;
-  std::mt19937 gen(rd());
 
   for (auto & p : particles_) {
     std::normal_distribution<double> noise_dx(0.0, std::abs(dx) * noise_translation_);
@@ -540,11 +539,11 @@ AMCLLocalizer::predict([[maybe_unused]] NavState & nav_state)
       rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_);
 
     tf2::Vector3 noisy_translation(
-      dx + noise_dx(gen),
-      dy + noise_dy(gen),
-      dz + noise_dz(gen));
+      dx + noise_dx(rng_),
+      dy + noise_dy(rng_),
+      dz + noise_dz(rng_));
 
-    double noisy_yaw = yaw + noise_yaw(gen);
+    double noisy_yaw = yaw + noise_yaw(rng_);
     tf2::Quaternion noisy_q;
     noisy_q.setRPY(0.0, 0.0, noisy_yaw);
 

--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -570,7 +570,7 @@ AMCLLocalizer::correct(NavState & nav_state)
     return;
   }
 
-  const auto perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
   if (!nav_state.has("map.static")) {
     RCLCPP_WARN(get_node()->get_logger(), "There is yet no a map.static map");

--- a/localizers/easynav_navmap_localizer/include/easynav_navmap_localizer/AMCLLocalizer.hpp
+++ b/localizers/easynav_navmap_localizer/include/easynav_navmap_localizer/AMCLLocalizer.hpp
@@ -234,7 +234,6 @@ protected:
    * @brief Internal static map.
    */
   std::shared_ptr<Bonxai::ProbabilisticMap> bonxai_map_;
-  ::navmap::NavMap navmap_;
   ::navmap::NavCelId last_cid_ {0};
 
   // PerceptionModel percepcion_model_;

--- a/localizers/easynav_navmap_localizer/include/easynav_navmap_localizer/AMCLLocalizer.hpp
+++ b/localizers/easynav_navmap_localizer/include/easynav_navmap_localizer/AMCLLocalizer.hpp
@@ -184,7 +184,7 @@ protected:
   std::vector<Particle> particles_;
 
   /// Random number generator used for sampling noise.
-  std::default_random_engine rng_;
+  std::mt19937 rng_;
 
   /// Current estimated odometry-based pose.
   tf2::Transform pose_;

--- a/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
@@ -496,7 +496,7 @@ void AMCLLocalizer::update_odom_from_tf()
 std::optional<tf2::Quaternion> get_latest_imu_quat(const NavState & nav_state)
 {
   if (!nav_state.has("imu")) {return std::nullopt;}
-  const auto imus = nav_state.get<IMUPerceptions>("imu");
+  const auto & imus = nav_state.get<IMUPerceptions>("imu");
   if (imus.empty() || !imus.back()) {return std::nullopt;}
   const auto & imu_msg = imus.back()->data;
   tf2::Quaternion q(imu_msg.orientation.x, imu_msg.orientation.y,
@@ -529,7 +529,9 @@ void AMCLLocalizer::predict(NavState & nav_state)
 
   tf2::Transform delta = last_odom_.inverseTimes(odom_);
   const bool have_navmap = nav_state.has("map.navmap");
-  if (have_navmap) {navmap_ = nav_state.get<::navmap::NavMap>("map.navmap");}
+
+  if (!have_navmap) {return;}
+  const auto & navmap = nav_state.get<::navmap::NavMap>("map.navmap");
 
   const auto imu_q_opt = get_latest_imu_quat(nav_state);
 
@@ -565,7 +567,7 @@ void AMCLLocalizer::predict(NavState & nav_state)
       Eigen::Vector3f bary, hit_eig;
 
       auto ta = get_node()->now();
-      const bool ok = navmap_.locate_navcel(
+      const bool ok = navmap.locate_navcel(
         Eigen::Vector3f(static_cast<float>(Pw.x()), static_cast<float>(Pw.y()),
             static_cast<float>(Pw.z())),
         sidx, cid, bary, &hit_eig, opts);
@@ -577,7 +579,7 @@ void AMCLLocalizer::predict(NavState & nav_state)
         if (imu_q_opt.has_value()) {
           p.pose.setRotation(*imu_q_opt);
         } else {
-          const auto & cel = navmap_.navcels[cid];
+          const auto & cel = navmap.navcels[cid];
           tf2::Vector3 n_world = to_tf(cel.normal);
           double nlen = n_world.length();
           if (nlen > 1e-9) {
@@ -692,7 +694,7 @@ void AMCLLocalizer::correct(NavState & nav_state)
     RCLCPP_WARN(get_node()->get_logger(), "No points perceptions yet");
     return;
   }
-  const auto perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
   if (!nav_state.has("map.bonxai")) {
     RCLCPP_WARN(get_node()->get_logger(), "No Bonxai map yet");
@@ -701,7 +703,7 @@ void AMCLLocalizer::correct(NavState & nav_state)
 
   // Build inflated map once and cache in NavState
   if (!nav_state.has("map.bonxai.inflated")) {
-    const auto original_map = nav_state.get_ptr<Bonxai::ProbabilisticMap>("map.bonxai");
+    const auto & original_map = nav_state.get_ptr<Bonxai::ProbabilisticMap>("map.bonxai");
     auto logger = get_node()->get_logger();
     auto clock = get_node()->get_clock();
     auto progress_cb = [logger, clock](float f) {
@@ -717,8 +719,8 @@ void AMCLLocalizer::correct(NavState & nav_state)
     nav_state.set("map.bonxai.inflated", inflated_map);
   }
 
-  const auto original_map = nav_state.get_ptr<Bonxai::ProbabilisticMap>("map.bonxai");
-  const auto inflated_map = nav_state.get_ptr<Bonxai::ProbabilisticMap>("map.bonxai.inflated");
+  const auto & original_map = nav_state.get_ptr<Bonxai::ProbabilisticMap>("map.bonxai");
+  const auto & inflated_map = nav_state.get_ptr<Bonxai::ProbabilisticMap>("map.bonxai.inflated");
 
   // Compute tail-skip coherent with inflation kernel
   const int TAIL_SKIP = compute_tail_skip(*original_map, inflation_stddev_, inflation_prob_min_);

--- a/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
@@ -377,7 +377,7 @@ void AMCLLocalizer::correct(NavState & nav_state)
     return;
   }
 
-  const auto perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
   if (!nav_state.has("map.static")) {
     RCLCPP_WARN(get_node()->get_logger(), "There is yet no a map.static map");

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
@@ -226,10 +226,10 @@ NavMapMapsManager::update(::easynav::NavState & nav_state)
     filter->set_map_resolution(resolution_);
     filter->update(nav_state);
 
-    navmap_ = nav_state.get<::navmap::NavMap>("map.navmap");
+    const auto & navmap = nav_state.get<::navmap::NavMap>("map.navmap");
 
-    if (filter->is_adding_layer() && navmap_.has_layer(filter->get_layer_name())) {
-      auto update_msg = navmap_ros::to_msg(navmap_, filter->get_layer_name());
+    if (filter->is_adding_layer() && navmap.has_layer(filter->get_layer_name())) {
+      auto update_msg = navmap_ros::to_msg(navmap, filter->get_layer_name());
       layer_updates_pub_->publish(update_msg);
     }
   }

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/InflationFilter.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/InflationFilter.cpp
@@ -227,10 +227,10 @@ void InflationFilter::update(::easynav::NavState & nav_state)
     return;
   }
 
-  auto nm = nav_state.get<::navmap::NavMap>("map.navmap");
+  navmap_ = nav_state.get<::navmap::NavMap>("map.navmap");
 
   const bool ok = inflate_layer_u8(
-    nm,
+    navmap_,
     "obstacles",
     "inflated_obstacles",
     inflation_radius_,
@@ -242,7 +242,7 @@ void InflationFilter::update(::easynav::NavState & nav_state)
     return;
   }
 
-  nav_state.set("map.navmap", nm);
+  nav_state.set("map.navmap", navmap_);
 }
 
 }  // namespace navmap

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -108,14 +108,14 @@ void CostmapPlanner::update(NavState & nav_state)
     return;
   }
 
-  const auto goals = nav_state.get<nav_msgs::msg::Goals>("goals");
+  const auto & goals = nav_state.get<nav_msgs::msg::Goals>("goals");
   if (goals.goals.empty()) {
     nav_state.set("path", current_path_);
     return;
   }
 
   const auto & map = nav_state.get<Costmap2D>("map.dynamic");
-  const auto robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
+  const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
 
   if (goals.header.frame_id != get_tf_prefix() + "map") {

--- a/planners/easynav_navmap_planner/include/easynav_navmap_planner/AStarPlanner.hpp
+++ b/planners/easynav_navmap_planner/include/easynav_navmap_planner/AStarPlanner.hpp
@@ -24,6 +24,8 @@
 #define EASYNAV_NAVMAP_PLANNER__NAVMAPPLANNER_HPP_
 
 #include <vector>
+#include <cstdint>
+#include <Eigen/Core>
 
 #include "nav_msgs/msg/path.hpp"
 
@@ -38,7 +40,7 @@ namespace navmap
 
 /// \brief A planner implementing the A* algorithm on a ::navmap::NavMap grid.
 ///
-/// This class generates a collision-free path using A* search over a 2D costmap.
+/// This class generates a collision-free path using A* search over a surface-based NavMap.
 /// It supports cost-based penalties and anisotropic movement costs.
 class AStarPlanner : public PlannerMethodBase
 {
@@ -54,7 +56,7 @@ public:
    * @brief Initializes the planner.
    *
    * Loads planner parameters, sets up ROS publishers,
-   * and prepares the costmap-based planning environment.
+   * and prepares the NavMap-based planning environment.
    *
    * @return std::expected<void, std::string> A success indicator or error message.
    */
@@ -71,16 +73,36 @@ public:
 
 protected:
   double cost_factor_;        ///< Scaling factor applied to cell cost values.
-  double inflation_penalty_; ///< Extra cost penalty for paths near inflated obstacles.
-  double cost_axial_;        ///< Cost multiplier for axial (horizontal/vertical) moves.
-  double cost_diagonal_;     ///< Cost multiplier for diagonal moves.
+  double inflation_penalty_;  ///< Extra cost penalty for paths near inflated obstacles.
+  double cost_axial_;         ///< Cost multiplier for axial (horizontal/vertical) moves.
+  double cost_diagonal_;      ///< Cost multiplier for diagonal moves.
   std::string layer_name_;
-  bool continuous_replan_ {true};    ///< Wheter replan path at freq time
+  bool continuous_replan_ {true};     ///< Whether to replan the path at control frequency.
   nav_msgs::msg::Path current_path_;  ///< Most recently computed path.
   geometry_msgs::msg::Pose current_goal_;  ///< Current goal.
 
   /// Publisher for the computed navigation path (for visualization or monitoring).
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr path_pub_;
+
+  /// Cached centroids for each NavCel (same indexing as ::navmap::NavMap::navcels).
+  std::vector<Eigen::Vector3f> centroids_;
+
+  /// Cached per-NavCel occupancy / cost values (0..255).
+  std::vector<std::uint8_t> occ_;
+
+  /// Reusable buffers for A* search cost and parent links.
+  std::vector<double> g_;
+  std::vector<::navmap::NavCelId> parent_;
+
+  /**
+   * @brief Ensure internal caches (centroids and A* buffers) are sized for the given map.
+   *
+   * This avoids reallocations on every planning call. Values in g_ and parent_
+   * are reset for the current run.
+   *
+   * @param map The NavMap for which caches must be valid.
+   */
+  void ensure_graph_cache(const ::navmap::NavMap & map);
 
   /**
    * @brief Smooth a Path in XY while keeping every waypoint inside its original NavCel.
@@ -113,27 +135,21 @@ protected:
   /**
    * @brief Internal A* path planning routine.
    *
-   * Computes a path on the given costmap from the start pose to the goal pose.
+   * Computes a path on the given NavMap from the start pose to the goal pose.
    *
    * Movement cost is influenced by:
-   * - The cost of each cell (retrieved from the costmap).
+   * - The cost of each NavCel (retrieved from a layer).
    * - Additional inflation penalties near obstacles.
-   * - Anisotropic weights for axial vs diagonal movement.
    *
-   * @param map The costmap to plan over.
+   * @param map   The NavMap to plan over.
    * @param start The robot's starting pose in world coordinates.
-   * @param goal The goal pose in world coordinates.
+   * @param goal  The goal pose in world coordinates.
    * @return A vector of poses representing the planned path.
    */
   std::vector<geometry_msgs::msg::Pose> a_star_path(
     const ::navmap::NavMap & map,
     const geometry_msgs::msg::Pose & start,
     const geometry_msgs::msg::Pose & goal);
-
-  /**
-   * @brief Internal static map.
-   */
-  ::navmap::NavMap navmap_;
 };
 
 }  // namespace navmap

--- a/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
+++ b/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
@@ -25,6 +25,7 @@
 #include <limits>
 #include <optional>
 #include <algorithm>
+#include <cstdint>
 
 #include "easynav_navmap_planner/AStarPlanner.hpp"
 
@@ -67,11 +68,9 @@ std::expected<void, std::string> AStarPlanner::on_initialize()
   const auto & plugin_name = get_plugin_name();
 
   node->declare_parameter<double>(plugin_name + ".cost_factor", 2.0);
-  node->declare_parameter<double>(plugin_name + ".inflation_penalty", 5.0);
   node->declare_parameter<bool>(plugin_name + ".continuous_replan", true);
 
   node->get_parameter(plugin_name + ".cost_factor", cost_factor_);
-  node->get_parameter(plugin_name + ".inflation_penalty", inflation_penalty_);
   node->get_parameter(plugin_name + ".continuous_replan", continuous_replan_);
 
   path_pub_ = node->create_publisher<nav_msgs::msg::Path>(
@@ -86,16 +85,15 @@ void AStarPlanner::update(NavState & nav_state)
     return;
   }
 
-
-  const auto goals = nav_state.get<nav_msgs::msg::Goals>("goals");
-  if (goals.goals.empty()) {
+  const auto & goals = nav_state.get<nav_msgs::msg::Goals>("goals");
+  if (goals.goals.empty() || !nav_state.has("map.navmap")) {
     nav_state.set("path", current_path_);
     return;
   }
 
-  navmap_ = nav_state.get<::navmap::NavMap>("map.navmap");
+  const auto & navmap = nav_state.get<::navmap::NavMap>("map.navmap");
 
-  const auto robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
+  const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
 
   if (goals.header.frame_id != get_tf_prefix() + "map") {
@@ -113,7 +111,6 @@ void AStarPlanner::update(NavState & nav_state)
   }
 
   current_goal_ = goal;
-  auto poses = a_star_path(navmap_, robot_pose.pose.pose, goal);
   if (!poses.empty()) {
     current_path_.header.stamp = get_node()->now();
     current_path_.header.frame_id = goals.header.frame_id;
@@ -126,7 +123,7 @@ void AStarPlanner::update(NavState & nav_state)
       current_path_.poses.push_back(std::move(ps));
     }
 
-    current_path_ = path_smoother(current_path_, navmap_);
+    current_path_ = path_smoother(current_path_, navmap);
 
     if (path_pub_->get_subscription_count() > 0) {
       path_pub_->publish(current_path_);
@@ -134,7 +131,6 @@ void AStarPlanner::update(NavState & nav_state)
   }
   nav_state.set("path", current_path_);
 }
-
 
 nav_msgs::msg::Path
 AStarPlanner::path_smoother(
@@ -160,9 +156,10 @@ AStarPlanner::path_smoother(
   // Fill pts from input and locate cids
   for (size_t i = 0; i < N; ++i) {
     const auto & p = out.poses[i].pose.position;
-    pts[i] = Eigen::Vector3f(static_cast<float>(p.x),
-                             static_cast<float>(p.y),
-                             static_cast<float>(p.z));
+    pts[i] = Eigen::Vector3f(
+      static_cast<float>(p.x),
+      static_cast<float>(p.y),
+      static_cast<float>(p.z));
   }
 
   // Use walking hints to speed up sequential location
@@ -198,7 +195,8 @@ AStarPlanner::path_smoother(
   }
 
   // Helper to fetch triangle vertices (A,B,C) for a cid
-  auto get_triangle_vertices = [&](::navmap::NavCelId cid) -> std::array<Eigen::Vector3f, 3> {
+  auto get_triangle_vertices =
+    [&](::navmap::NavCelId cid) -> std::array<Eigen::Vector3f, 3> {
       const ::navmap::NavCel & tri = navmap.navcels[cid];
       const auto A = navmap.positions.at(tri.v[0]);
       const auto B = navmap.positions.at(tri.v[1]);
@@ -207,8 +205,8 @@ AStarPlanner::path_smoother(
     };
 
   // Helper: clamp a 3D point to the triangle of a given cid (closest point)
-  auto clamp_to_triangle = [&](const Eigen::Vector3f & p,
-    ::navmap::NavCelId cid) -> Eigen::Vector3f {
+  auto clamp_to_triangle =
+    [&](const Eigen::Vector3f & p, ::navmap::NavCelId cid) -> Eigen::Vector3f {
       const auto V = get_triangle_vertices(cid);
       return ::navmap::closest_point_on_triangle(p, V[0], V[1], V[2]);
     };
@@ -263,7 +261,7 @@ AStarPlanner::path_smoother(
       // Clamp to the *original* triangle of this point
       Eigen::Vector3f clamped = clamp_to_triangle(cand3, cids[i]);
 
-      next[i] = clamped; // already lies on triangle plane, z' consistent
+      next[i] = clamped;  // already lies on triangle plane, z' consistent
     }
     curr.swap(next);
   }
@@ -285,6 +283,42 @@ static inline bool layer_exists(const ::navmap::NavMap & nm, const std::string &
   return static_cast<bool>(nm.layers.get(name));
 }
 
+void AStarPlanner::ensure_graph_cache(const ::navmap::NavMap & map)
+{
+  const std::size_t N = map.navcels.size();
+
+  // Cache centroids: only recompute when the number of NavCels changes.
+  if (centroids_.size() != N) {
+    centroids_.resize(N);
+    for (::navmap::NavCelId c = 0; c < static_cast<::navmap::NavCelId>(N); ++c) {
+      const auto cc = map.navcel_centroid(c);
+      centroids_[c] = Eigen::Vector3f{cc.x(), cc.y(), cc.z()};
+    }
+  }
+
+  // Ensure occupancy buffer has the right size (values are filled per-planning call).
+  if (occ_.size() != N) {
+    occ_.resize(N);
+  }
+
+  // Resize and reset A* buffers.
+  const double inf = std::numeric_limits<double>::infinity();
+
+  if (g_.size() != N) {
+    g_.assign(N, inf);
+  } else {
+    std::fill(g_.begin(), g_.end(), inf);
+  }
+
+  if (parent_.size() != N) {
+    parent_.assign(N, std::numeric_limits<::navmap::NavCelId>::max());
+  } else {
+    std::fill(
+      parent_.begin(), parent_.end(),
+      std::numeric_limits<::navmap::NavCelId>::max());
+  }
+}
+
 std::vector<geometry_msgs::msg::Pose> AStarPlanner::a_star_path(
   const ::navmap::NavMap & nm,
   const geometry_msgs::msg::Pose & start,
@@ -296,146 +330,162 @@ std::vector<geometry_msgs::msg::Pose> AStarPlanner::a_star_path(
   if (nm.navcels.empty()) {return {};}
 
   // 1) Locate start and goal NavCels (fallback to closest triangle if necessary)
-  size_t sidx_s = 0, sidx_g = 0;
+  std::size_t sidx_s = 0, sidx_g = 0;
   NavCelId cid_start = 0, cid_goal = 0;
-  Eigen::Vector3f bary; Eigen::Vector3f hit;
+  Eigen::Vector3f bary;
+  Eigen::Vector3f hit;
 
   Eigen::Vector3f pS(start.position.x, start.position.y, start.position.z);
   Eigen::Vector3f pG(goal.position.x, goal.position.y, goal.position.z);
 
   bool okS = nm.locate_navcel(pS, sidx_s, cid_start, bary, &hit);
   if (!okS) {
-    Eigen::Vector3f q; float d2;
+    Eigen::Vector3f q;
+    float d2;
     if (!nm.closest_navcel(pS, sidx_s, cid_start, q, d2)) {return {};}
   }
   bool okG = nm.locate_navcel(pG, sidx_g, cid_goal, bary, &hit);
   if (!okG) {
-    Eigen::Vector3f q; float d2;
+    Eigen::Vector3f q;
+    float d2;
     if (!nm.closest_navcel(pG, sidx_g, cid_goal, q, d2)) {return {};}
   }
 
-  const size_t N = nm.navcels.size();
+  const std::size_t N = nm.navcels.size();
 
-  // 2) Precompute centroids (used for cost, heuristic, and edge lengths)
-  std::vector<Eigen::Vector3f> C(N);
-  for (NavCelId c = 0; c < N; ++c) {
-    const auto cc = nm.navcel_centroid(c);
-    C[c] = {cc.x(), cc.y(), cc.z()};
-  }
-
-  auto euclid = [&](NavCelId a, NavCelId b) -> double {
-      const auto d = C[a] - C[b];
-      return static_cast<double>(d.norm());
-    };
-
-  // 3) Choose cost layer: prefer "inflated_obstacles", fallback to "obstacles"
+  // 2) Choose cost layer: prefer "inflated_obstacles", fallback to "obstacles"
   const std::string cost_layer =
     layer_exists(nm, "inflated_obstacles") ? "inflated_obstacles" : "obstacles";
 
-  // Cache per-NavCel uint8_t cost values (0..255)
-  std::vector<std::uint8_t> occ(N, FREE_SPACE);
-  for (NavCelId c = 0; c < N; ++c) {
-    // If the cell has no stored value, assume FREE_SPACE (0)
-    occ[c] = nm.layer_get<std::uint8_t>(cost_layer, c, FREE_SPACE);
+  // Ensure cached buffers match the current NavMap.
+  ensure_graph_cache(nm);
+
+  // Precomputed centroids in `centroids_` are used for cost, heuristic, and edge lengths.
+  auto euclid = [&](NavCelId a, NavCelId b) -> double {
+      const auto d = centroids_[a] - centroids_[b];
+      return static_cast<double>(d.norm());
+    };
+
+  // Cache per-NavCel uint8_t cost values (0..255) for the selected layer.
+  for (NavCelId c = 0; c < static_cast<NavCelId>(N); ++c) {
+    // If the cell has no stored value, assume FREE_SPACE (0).
+    occ_[c] = nm.layer_get<std::uint8_t>(cost_layer, c, FREE_SPACE);
   }
 
-  // Traversability: block lethal and unknown
+  // Traversability: block lethal and unknown.
   auto traversable = [&](NavCelId c) -> bool {
-      const std::uint8_t v = occ[c];
+      const std::uint8_t v = occ_[c];
       return (v != LETHAL_OBSTACLE) && (v != NO_INFORMATION);
     };
 
-  // Normalize a uint8_t cost into [0, 1]; FREE_SPACE=0 → 0.0; INSCRIBED=253 → ~1.0
+  // Normalize a uint8_t cost into [0, 1]; FREE_SPACE=0 → 0.0; INSCRIBED=253 → ~1.0.
   // Returns +inf for non-traversable (lethal/unknown).
   auto normalized_cost = [&](NavCelId c) -> double {
-      const std::uint8_t v = occ[c];
+      const std::uint8_t v = occ_[c];
       if (v == LETHAL_OBSTACLE || v == NO_INFORMATION) {
         return std::numeric_limits<double>::infinity();
       }
-    // cap at INSCRIBED_INFLATED_OBSTACLE to avoid division by 0 at 254/255
-      const double max_cost = static_cast<double>(INSCRIBED_INFLATED_OBSTACLE); // 253
-      return static_cast<double>(v) / max_cost; // FREE=0 → 0.0, INSCRIBED=253 → 1.0
+      // Cap at INSCRIBED_INFLATED_OBSTACLE to avoid division by 0 at 254/255.
+      const double max_cost = static_cast<double>(INSCRIBED_INFLATED_OBSTACLE);  // 253
+      return static_cast<double>(v) / max_cost;  // FREE=0 → 0.0, INSCRIBED=253 → 1.0
     };
 
-  // If start or goal lands on non-traversable, do not plan
+  // If start or goal lands on non-traversable, do not plan.
   if (!traversable(cid_start) || !traversable(cid_goal)) {
     return {};
   }
 
   // Weighted step cost:
-  //   base geometric cost (edge length) scaled by (cost_factor_ + inflation_penalty_ * norm_cost(target))
+  //   base geometric cost (edge length) scaled by (cost_factor_ + inflation_penalty_ * norm_cost(target)).
   // This preserves admissibility with heuristic h = Euclidean distance, since the minimal multiplier ≥ 1.
   auto step_cost = [&](NavCelId from, NavCelId to) -> double {
       const double base = euclid(from, to);
-      if (!std::isfinite(base) || base <= 0.0) {return std::numeric_limits<double>::infinity();}
+      if (!std::isfinite(base) || base <= 0.0) {
+        return std::numeric_limits<double>::infinity();
+      }
 
       const double ncost = normalized_cost(to);
-      if (!std::isfinite(ncost)) {return std::numeric_limits<double>::infinity();}
+      if (!std::isfinite(ncost)) {
+        return std::numeric_limits<double>::infinity();
+      }
 
-    // Ensure the multiplier is at least 1.0 so h = euclid remains admissible.
-    // If your cost_factor_ is already ≥ 1, this holds. Otherwise we clamp.
+      // Ensure the multiplier is at least 1.0 so h = euclid remains admissible.
+      // If your cost_factor_ is already ≥ 1, this holds. Otherwise we clamp.
       const double cf = std::max(1.0, static_cast<double>(cost_factor_));
       const double mult = cf + static_cast<double>(inflation_penalty_) * ncost;
 
       return base * mult;
     };
 
-  // 4) A* search on the triangle graph, using cost-aware edges
-  struct Node { NavCelId cid; double f; };
-  struct Cmp { bool operator()(const Node & a, const Node & b) const {return a.f > b.f;} };
+  // 4) A* search on the triangle graph, using cost-aware edges.
+  struct Node
+  {
+    NavCelId cid;
+    double f;
+  };
+  struct Cmp
+  {
+    bool operator()(const Node & a, const Node & b) const {return a.f > b.f;}
+  };
 
   std::priority_queue<Node, std::vector<Node>, Cmp> open;
-  std::vector<double> g(N, std::numeric_limits<double>::infinity());
-  std::vector<NavCelId> parent(N, std::numeric_limits<NavCelId>::max());
-  std::vector<uint8_t> in_open(N, 0);
 
   auto h = [&](NavCelId a, NavCelId b) -> double {
-    // Heuristic: pure Euclidean distance → admissible (never overestimates)
+      // Heuristic: pure Euclidean distance → admissible (never overestimates).
       return euclid(a, b);
     };
 
-  g[cid_start] = 0.0;
+  g_[cid_start] = 0.0;
   open.push(Node{cid_start, h(cid_start, cid_goal)});
-  in_open[cid_start] = 1;
 
   while (!open.empty()) {
-    const auto cur = open.top(); open.pop();
+    const auto cur = open.top();
+    open.pop();
     const NavCelId u = cur.cid;
 
     if (u == cid_goal) {break;}
 
-    for (NavCelId v : nm.navcel_neighbors(u)) {
-      const size_t vidx = static_cast<size_t>(v);
-      if (vidx >= N) {continue;}
+    const auto & tri = nm.navcels[u];
+    for (int e = 0; e < 3; ++e) {
+      NavCelId v = tri.neighbor[e];
+      if (v == std::numeric_limits<std::uint32_t>::max()) {
+        continue;
+      }
+      const std::size_t vidx = static_cast<std::size_t>(v);
+      if (vidx >= N) {
+        continue;
+      }
 
-      // Skip non-traversable neighbors (lethal or unknown)
+      // Skip non-traversable neighbors (lethal or unknown).
       if (!traversable(v)) {continue;}
 
       const double sc = step_cost(u, v);
       if (!std::isfinite(sc)) {continue;}
 
-      const double tentative = g[u] + sc;
-      if (tentative < g[v]) {
-        g[v] = tentative;
-        parent[v] = u;
+      const double tentative = g_[u] + sc;
+      if (tentative < g_[v]) {
+        g_[v] = tentative;
+        parent_[v] = u;
         const double f = tentative + h(v, cid_goal);
         open.push(Node{v, f});
-        in_open[v] = 1;
       }
     }
   }
 
-  if (!std::isfinite(g[cid_goal])) {
+  if (!std::isfinite(g_[cid_goal])) {
     return {};
   }
 
-  // 5) Path reconstruction (centroid-based polyline)
+  // 5) Path reconstruction (centroid-based polyline).
   std::vector<geometry_msgs::msg::Pose> path;
-  for (NavCelId c = cid_goal; c != std::numeric_limits<NavCelId>::max(); c = parent[c]) {
+  for (NavCelId c = cid_goal;
+    c != std::numeric_limits<NavCelId>::max();
+    c = parent_[c])
+  {
     geometry_msgs::msg::Pose p;
-    p.position.x = C[c].x();
-    p.position.y = C[c].y();
-    p.position.z = C[c].z();
+    p.position.x = centroids_[c].x();
+    p.position.y = centroids_[c].y();
+    p.position.z = centroids_[c].z();
     p.orientation = goal.orientation;
     path.push_back(std::move(p));
     if (c == cid_start) {break;}

--- a/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
+++ b/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
@@ -97,8 +97,9 @@ void AStarPlanner::update(NavState & nav_state)
   const auto & goal = goals.goals.front().pose;
 
   if (goals.header.frame_id != get_tf_prefix() + "map") {
-    RCLCPP_WARN(get_node()->get_logger(), "Goals frame is not 'map': %s",
-                goals.header.frame_id.c_str());
+    RCLCPP_WARN(
+      get_node()->get_logger(), "Goals frame is not 'map': %s",
+      goals.header.frame_id.c_str());
     return;
   }
 
@@ -111,6 +112,7 @@ void AStarPlanner::update(NavState & nav_state)
   }
 
   current_goal_ = goal;
+  auto poses = a_star_path(navmap, robot_pose.pose.pose, goal);
   if (!poses.empty()) {
     current_path_.header.stamp = get_node()->now();
     current_path_.header.frame_id = goals.header.frame_id;

--- a/planners/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
+++ b/planners/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
@@ -110,7 +110,7 @@ SimplePlanner::update(NavState & nav_state)
   if (!nav_state.has("goals")) {return;}
   if (!nav_state.has("robot_pose")) {return;}
 
-  const auto goals = nav_state.get<nav_msgs::msg::Goals>("goals");
+  const auto & goals = nav_state.get<nav_msgs::msg::Goals>("goals");
 
   if (goals.goals.empty()) {
     nav_state.set("path", current_path_);
@@ -130,7 +130,7 @@ SimplePlanner::update(NavState & nav_state)
     return;
   }
 
-  const auto robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
+  const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
 
   auto downsampled_map = map_typed.downsample(0.2);


### PR DESCRIPTION
This PR introduces new optimizations by:

- Using `const auto &` in most `nav_state_.get<` calls.
- Cache geometry in NavMap A* path planner.

It also solves a link error in execution from the Simple Controller when built with the release flag.

Example of navigating with NavMap in A*:
<img width="1417" height="641" alt="Captura desde 2025-11-24 08-05-51" src="https://github.com/user-attachments/assets/b929b045-5993-46fd-8b49-48ae6a746462" />
