### PR TITLE
Fix: Costmap inflation and A* planner collision avoidance

### DIFF
--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/InflationFilter.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/InflationFilter.cpp
@@ -77,16 +77,19 @@ InflationFilter::on_initialize()
   auto node = get_node();
 
   inflation_radius_ = 0.3;
+  inscribed_radius_ = 0.25;
   cost_scaling_factor_ = 3.0;
 
   node->declare_parameter(plugin_name_ + ".inflation_radius", inflation_radius_);
+  node->declare_parameter(plugin_name_ + ".inscribed_radius", inscribed_radius_);
   node->declare_parameter(plugin_name_ + ".cost_scaling_factor", cost_scaling_factor_);
   node->get_parameter(plugin_name_ + ".inflation_radius", inflation_radius_);
+  node->get_parameter(plugin_name_ + ".inscribed_radius", inscribed_radius_);
   node->get_parameter(plugin_name_ + ".cost_scaling_factor", cost_scaling_factor_);
 
   RCLCPP_INFO(node->get_logger(),
-    "InflationFilter with inflation_radius = %lf  cost_scaling_factor = %lf",
-    inflation_radius_, cost_scaling_factor_);
+    "InflationFilter with inflation_radius = %lf  inscribed_radius = %lf  cost_scaling_factor = %lf",
+    inflation_radius_, inscribed_radius_, cost_scaling_factor_);
 
   seen_.clear();
   cached_distances_.clear();

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -189,14 +189,11 @@ std::vector<geometry_msgs::msg::Pose> CostmapPlanner::a_star_path(
       if (!map.inBounds(nx, ny)) {continue;}
 
       uint8_t cell_cost = map.getCost(nx, ny);
-      if (cell_cost >= LETHAL_OBSTACLE) {continue;}
+      // Reject cells that would cause collision (>= INSCRIBED_INFLATED_OBSTACLE = 253)
+      if (cell_cost >= INSCRIBED_INFLATED_OBSTACLE) {continue;}
 
+      // Calculate traversal cost for free and lightly inflated cells
       double traversal_cost = 1.0 + cost_factor_ * static_cast<double>(cell_cost) / LETHAL_OBSTACLE;
-      if (cell_cost >= INSCRIBED_INFLATED_OBSTACLE) {
-        double inflation_ratio = static_cast<double>(cell_cost - INSCRIBED_INFLATED_OBSTACLE) /
-          (LETHAL_OBSTACLE - INSCRIBED_INFLATED_OBSTACLE);
-        traversal_cost += inflation_penalty_ * inflation_ratio;
-      }
 
       double step_cost = (dx == 0 || dy == 0) ? cost_axial_ : cost_diagonal_;
       double new_cost = cost_so_far[idx(current.x, current.y)] + traversal_cost * step_cost;


### PR DESCRIPTION
## Problem
When increasing `inflation_radius` from 0.3 to 0.8, the A* planner was generating paths that passed through obstacles. 

Two critical issues were identified:

1. **InflationFilter**: The `inscribed_radius_` parameter was never initialized, causing incorrect cost computation in the exponential decay function. All inflated cells received near-zero costs instead of proper gradient values.

2. **CostmapPlanner (A)***: The planner allowed traversal through cells with cost value `INSCRIBED_INFLATED_OBSTACLE` (253), which represents the inscribed radius where the robot center would cause a collision.

## Solution
### `InflationFilter.cpp`:

- Added `inscribed_radius_` parameter declaration and initialization (default: 0.25m)
- Now properly reads inscribed_radius from ROS parameters
- Updated logging to include inscribed_radius value
- This ensures correct cost computation: cells within inscribed_radius get cost 253, and costs decay exponentially from there to the inflation_radius

### `CostmapPlanner.cpp`:

- Changed obstacle rejection threshold from `>= LETHAL_OBSTACLE` (254) to `>= INSCRIBED_INFLATED_OBSTACLE` (253)
- Removed redundant inflation penalty calculation (already handled by InflationFilter)
- Added clarifying comments for the collision avoidance logic
- Now the planner strictly avoids any cell where the robot center would be within `inscribed_radius` of an obstacle

### Cost Map Behavior After Fix
- **Distance 0**: Cost = 254 (LETHAL_OBSTACLE) → Blocked
- **Distance 0 to inscribed_radius (0.25m)**: Cost = 253 (INSCRIBED_INFLATED_OBSTACLE) → Blocked
- **Distance inscribed_radius to inflation_radius (0.8m)**: Cost decays exponentially from ~252 to 0 → Penalized but traversable
- **Distance > inflation_radius**: Cost = 0 → Free space

### Configuration
Users must now specify `inscribed_radius` in their config files (typically matching `robot_radius`):

```
inflation:
  plugin: easynav_costmap_maps_manager/CostmapMapsManager/InflationFilter
  inflation_radius: 0.8
  inscribed_radius: 0.25  # NEW: Should match robot radius
  cost_scaling_factor: 3.0
```