### PR TITLE
Fix path planner and controllers

### DIFF
--- a/controllers/easynav_mpc_controller/CMakeLists.txt
+++ b/controllers/easynav_mpc_controller/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(ament_cmake REQUIRED)
 find_package(easynav_common REQUIRED)
 find_package(easynav_core REQUIRED)
+find_package(easynav_system REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -44,6 +45,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME} PUBLIC
   easynav_common::easynav_common
   easynav_core::easynav_core
+  easynav_system::easynav_system
   tf2_ros::tf2_ros
   pluginlib::pluginlib
   Eigen3::Eigen

--- a/controllers/easynav_mpc_controller/include/easynav_mpc_controller/MPCController.hpp
+++ b/controllers/easynav_mpc_controller/include/easynav_mpc_controller/MPCController.hpp
@@ -73,6 +73,10 @@ protected:
   double max_ang_vel_{1.5};     ///< Maximum angular velocity for MPC.
   bool verbose_{false};         ///< Value to debug on terminal
 
+  // Fallback goal tolerances if GoalManager does not publish them
+  double fallback_goal_pos_tol_{0.05};   ///< Default positional tolerance (meters).
+  double fallback_goal_yaw_tol_{0.05};   ///< Default angular tolerance (radians).
+
   std::unique_ptr<MPCOptimizer> optimizer_;  ///< MPC optimizer
 
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr mpc_path_pub_;            ///< Publisher for MPC path.

--- a/controllers/easynav_mpc_controller/package.xml
+++ b/controllers/easynav_mpc_controller/package.xml
@@ -14,6 +14,7 @@
 
   <depend>easynav_common</depend>
   <depend>easynav_core</depend>
+  <depend>easynav_system</depend>
   <depend>pluginlib</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>

--- a/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
+++ b/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
@@ -43,12 +43,18 @@ MPCController::on_initialize()
   node->declare_parameter<double>(plugin_name + ".max_angular_velocity", max_ang_vel_);
   node->declare_parameter<bool>(plugin_name + ".verbose", verbose_);
 
+  node->declare_parameter<double>(plugin_name + ".fallback_goal_pos_tol", fallback_goal_pos_tol_);
+  node->declare_parameter<double>(plugin_name + ".fallback_goal_yaw_tol", fallback_goal_yaw_tol_);
+
   node->get_parameter<int>(plugin_name + ".horizon_steps", horizon_steps_);
   node->get_parameter<double>(plugin_name + ".dt", dt_);
   node->get_parameter<double>(plugin_name + ".safety_radius", safety_radius_);
   node->get_parameter<double>(plugin_name + ".max_linear_velocity", max_lin_vel_);
   node->get_parameter<double>(plugin_name + ".max_angular_velocity", max_ang_vel_);
   node->get_parameter<bool>(plugin_name + ".verbose", verbose_);
+
+  node->get_parameter<double>(plugin_name + ".fallback_goal_pos_tol", fallback_goal_pos_tol_);
+  node->get_parameter<double>(plugin_name + ".fallback_goal_yaw_tol", fallback_goal_yaw_tol_);
 
   optimizer_ = std::make_unique<MPCOptimizer>();
 
@@ -266,6 +272,62 @@ MPCController::update_rt(NavState & nav_state)
   }
 
   collision_checker(&params, u);
+
+  // Final alignment phase with hysteresis on distance:
+  // - Enter when dist_to_goal <= 0.5 * pos_tol
+  // - Stay in this phase (even if dist grows slightly) until dist_to_goal > pos_tol
+  {
+    const auto & goal_pose = path.poses.back().pose;
+
+    double pos_tol = fallback_goal_pos_tol_;
+    double yaw_tol = fallback_goal_yaw_tol_;
+
+    if (nav_state.has("goal_tolerance.position")) {
+      pos_tol = nav_state.get<double>("goal_tolerance.position");
+    }
+    if (nav_state.has("goal_tolerance.yaw")) {
+      yaw_tol = nav_state.get<double>("goal_tolerance.yaw");
+    }
+
+    const double dx_g = goal_pose.position.x - pose.position.x;
+    const double dy_g = goal_pose.position.y - pose.position.y;
+    const double dist_to_goal = std::hypot(dx_g, dy_g);
+
+    const double yaw_goal = std::atan2(
+      2.0 * (goal_pose.orientation.w * goal_pose.orientation.z +
+      goal_pose.orientation.x * goal_pose.orientation.y),
+      1.0 - 2.0 * (goal_pose.orientation.y * goal_pose.orientation.y +
+      goal_pose.orientation.z * goal_pose.orientation.z));
+    double e_theta_goal = std::atan2(std::sin(yaw_ - yaw_goal), std::cos(yaw_ - yaw_goal));
+
+    const double enter_dist = 0.5 * pos_tol;
+
+    // Hysteresis based on distance to goal: start aligning when we are
+    // well inside the goal radius (enter_dist) and keep aligning until
+    // we move clearly outside (dist_to_goal > pos_tol).
+    const bool inside_hysteresis_band = (dist_to_goal <= pos_tol);
+    const bool should_enter_alignment = (dist_to_goal <= enter_dist);
+
+    if ((inside_hysteresis_band && std::fabs(e_theta_goal) > yaw_tol) ||
+      should_enter_alignment)
+    {
+      // Stay in place and rotate towards the goal orientation using a simple P controller
+      const double k_align = 1.0;
+      double vlin = 0.0;
+      double vrot = -k_align * e_theta_goal;
+
+      vrot = std::clamp(vrot, -max_ang_vel_, max_ang_vel_);
+
+      cmd_vel_.header.frame_id = path.header.frame_id;
+      cmd_vel_.header.stamp = get_node()->now();
+      cmd_vel_.twist.linear.x = vlin;
+      cmd_vel_.twist.angular.z = vrot;
+
+      nav_state.set("cmd_vel", cmd_vel_);
+      publish_mpc_path(&params, u, path);
+      return;
+    }
+  }
 
   // Publish the computed velocity command
   cmd_vel_.header.frame_id = path.header.frame_id;

--- a/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
+++ b/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
@@ -134,7 +134,7 @@ MPCController::update_rt(NavState & nav_state)
     return;
   }
 
-  const auto path = nav_state.get<nav_msgs::msg::Path>("path");
+  nav_msgs::msg::Path path = nav_state.get<nav_msgs::msg::Path>("path");
   if (path.poses.empty()) {
     // If the path is empty, stop the robot
     cmd_vel_.header.frame_id = path.header.frame_id;
@@ -144,6 +144,46 @@ MPCController::update_rt(NavState & nav_state)
     nav_state.set("cmd_vel", cmd_vel_);
     return;
   }
+
+  // Build a local path that:
+  // 1) keeps only the segment that brings the robot closer to the goal, and
+  // 2) prepends a short straight segment from the robot pose to that segment.
+  const auto & robot_pose_msg = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
+  const auto & robot_p = robot_pose_msg.pose.pose.position;
+
+  // Goal is the last point of the planner path
+  const auto & goal_p = path.poses.back().pose.position;
+
+  nav_msgs::msg::Path local_path;
+  local_path.header = path.header;
+  local_path.poses.clear();
+
+  // 1) Find the first index that actually brings us closer to the goal than our current pose
+  const double d_robot_goal = std::hypot(goal_p.x - robot_p.x, goal_p.y - robot_p.y);
+  std::size_t start_idx = 0;
+  for (std::size_t i = 0; i < path.poses.size(); ++i) {
+    const auto & pi = path.poses[i].pose.position;
+    const double d_pi_goal = std::hypot(goal_p.x - pi.x, goal_p.y - pi.y);
+    if (d_pi_goal <= d_robot_goal) {
+      start_idx = i;
+      break;
+    }
+  }
+
+  // 2) Prepend a point at the robot position to ensure continuity from the current pose
+  geometry_msgs::msg::PoseStamped robot_ps;
+  robot_ps.header = path.header;
+  robot_ps.pose.position = robot_p;
+  robot_ps.pose.orientation = path.poses[start_idx].pose.orientation;
+  local_path.poses.push_back(robot_ps);
+
+  // 3) Copy the remaining points from start_idx to the goal
+  for (std::size_t i = start_idx; i < path.poses.size(); ++i) {
+    local_path.poses.push_back(path.poses[i]);
+  }
+
+  // Use the local path from now on
+  path = local_path;
 
   int num_elements = path.poses.size();
   size_t local_horizon;

--- a/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
+++ b/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
@@ -21,6 +21,7 @@
 /// \brief Implementation of the MPCController class.
 
 #include "easynav_mpc_controller/MPCController.hpp"
+#include "easynav_system/GoalManager.hpp"
 
 namespace easynav
 {
@@ -114,6 +115,18 @@ MPCController::collision_checker(void *data, std::vector<double> & u)
 void
 MPCController::update_rt(NavState & nav_state)
 {
+  // If navigation is IDLE, force zero velocity
+  if (nav_state.has("navigation_state")) {
+    const auto nav_state_val = nav_state.get<easynav::GoalManager::State>("navigation_state");
+    if (nav_state_val == easynav::GoalManager::State::IDLE) {
+      cmd_vel_.header.stamp = get_node()->now();
+      cmd_vel_.twist.linear.x = 0.0;
+      cmd_vel_.twist.angular.z = 0.0;
+      nav_state.set("cmd_vel", cmd_vel_);
+      return;
+    }
+  }
+
   if (!nav_state.has("path") || !nav_state.has("robot_pose") || !nav_state.has("points")) {
     if(verbose_) {
       std::cout << "No Path, No Points or No Robot Pose" << std::endl;

--- a/controllers/easynav_mppi_controller/CMakeLists.txt
+++ b/controllers/easynav_mppi_controller/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(ament_cmake REQUIRED)
 find_package(easynav_common REQUIRED)
 find_package(easynav_core REQUIRED)
+find_package(easynav_system REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -32,6 +33,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME} PUBLIC
   easynav_common::easynav_common
   easynav_core::easynav_core
+  easynav_system::easynav_system
   tf2_ros::tf2_ros
   pluginlib::pluginlib
   ${geometry_msgs_TARGETS}

--- a/controllers/easynav_mppi_controller/package.xml
+++ b/controllers/easynav_mppi_controller/package.xml
@@ -11,6 +11,7 @@
 
   <depend>easynav_common</depend>
   <depend>easynav_core</depend>
+  <depend>easynav_system</depend>
   <depend>pluginlib</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>

--- a/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
+++ b/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
@@ -24,6 +24,7 @@
 
 #include "easynav_mppi_controller/MPPIController.hpp"
 #include "easynav_common/types/PointPerception.hpp"
+#include "easynav_system/GoalManager.hpp"
 
 #include "nav_msgs/msg/odometry.hpp"
 
@@ -140,6 +141,27 @@ void MPPIController::publish_mppi_markers(
 void
 MPPIController::update_rt(NavState & nav_state)
 {
+  // If navigation is IDLE, force zero velocity
+  if (nav_state.has("navigation_state")) {
+    const auto nav_state_val = nav_state.get<easynav::GoalManager::State>("navigation_state");
+    if (nav_state_val == easynav::GoalManager::State::IDLE) {
+      twist_stamped_.header.stamp = get_node()->now();
+      twist_stamped_.twist.linear.x = 0.0;
+      twist_stamped_.twist.angular.z = 0.0;
+      nav_state.set("cmd_vel", twist_stamped_);
+
+      // Also clear visualization markers when idle
+      visualization_msgs::msg::MarkerArray clear_markers;
+      visualization_msgs::msg::Marker delete_all;
+      delete_all.action = visualization_msgs::msg::Marker::DELETEALL;
+      clear_markers.markers.push_back(delete_all);
+
+      mppi_candidates_pub_->publish(clear_markers);
+      mppi_optimal_pub_->publish(clear_markers);
+      return;
+    }
+  }
+
   if (!nav_state.has("path") || !nav_state.has("robot_pose")) {
     return;
   }

--- a/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
+++ b/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <limits>
 #include <cmath>
+#include <numbers>
 
 #include "tf2/utils.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
@@ -401,10 +402,6 @@ SerestController::compute_goal_zone(
   double & stop_r, double & slow_r, double & gamma_slow,
   Vec2 & goal_xy, double & yaw_goal) const
 {
-  const double PI = 3.14159265358979323846;
-  const double goal_yaw_tol = goal_yaw_tol_deg_ * PI / 180.0;  // (no se devuelve, pero útil si quieres)
-  (void)goal_yaw_tol;
-
   const auto & pgoal = path.poses.back().pose.position;
   yaw_goal = tf2::getYaw(path.poses.back().pose.orientation);
   goal_xy = Vec2{pgoal.x, pgoal.y};
@@ -412,6 +409,9 @@ SerestController::compute_goal_zone(
   dist_xy_goal = std::hypot(robot_xy.x - goal_xy.x, robot_xy.y - goal_xy.y);
   e_theta_goal = std::atan2(std::sin(robot_yaw - yaw_goal), std::cos(robot_yaw - yaw_goal));
 
+  // Use externally provided goal position tolerance when available (via update_rt),
+  // which stores it in goal_pos_tol_. Here we only shape the radial zone using
+  // the current value of goal_pos_tol_ as stop radius.
   stop_r = std::max(0.0, goal_pos_tol_);
   slow_r = std::max(slow_radius_, stop_r + 0.05);
 
@@ -482,8 +482,7 @@ SerestController::should_turn_in_place(
 {
   // Mantenemos compatibilidad con la firma, pero ignoramos turn_in_place_thr
   // y usamos dos umbrales internos sin exponer parámetros.
-  const double PI = 3.14159265358979323846;
-  const double thr_enter = 60.0 * PI / 180.0; // entra a girar si |e_theta| > 60°
+  const double thr_enter = 60.0 * std::numbers::pi / 180.0; // entra a girar si |e_theta| > 60°
   // const double thr_exit = 35.0 * PI / 180.0; // sale de girar si |e_theta| < 35°
 
   // No permitimos “atajo” marcha atrás en esta decisión: si no permites reverse,
@@ -506,8 +505,7 @@ SerestController::maybe_final_align_and_publish(
   double dist_xy_goal, double stop_r, double e_theta_goal,
   double gamma_slow, double dt)
 {
-  const double PI = 3.14159265358979323846;
-  const double goal_yaw_tol = goal_yaw_tol_deg_ * PI / 180.0;
+  const double goal_yaw_tol = goal_yaw_tol_deg_ * std::numbers::pi / 180.0;
 
   if (dist_xy_goal > stop_r) {
     return false;
@@ -620,6 +618,16 @@ SerestController::update_rt(NavState & nav_state)
   nav_msgs::msg::Odometry odom;
   if (!fetch_required_inputs(nav_state, path, odom)) {return;}
 
+  // 1.5) Goal tolerances: prefer shared GoalManager values, fallback to local params
+  double goal_pos_tol = goal_pos_tol_;
+  double goal_yaw_tol = goal_yaw_tol_deg_ * (std::numbers::pi / 180.0);
+  if (nav_state.has("goal_tolerance.position")) {
+    goal_pos_tol = nav_state.get<double>("goal_tolerance.position");
+  }
+  if (nav_state.has("goal_tolerance.yaw")) {
+    goal_yaw_tol = nav_state.get<double>("goal_tolerance.yaw");
+  }
+
   // 2) Robot state (position + yaw)
   Vec2 robot_xy; double yaw = 0.0;
   robot_state_from_odom(odom, robot_xy, yaw);
@@ -714,8 +722,7 @@ SerestController::update_rt(NavState & nav_state)
   double v_prog_ref = v_prog_ref_free * gamma_slow;
 
   // Maintain a small cruising speed when roughly aligned and outside the stop zone (no reverse)
-  const double PI = 3.14159265358979323846;
-  const double align_thr = 30.0 * PI / 180.0;
+  const double align_thr = 30.0 * std::numbers::pi / 180.0;
   if (!allow_reverse_ && (dist_xy_goal > stop_r) && std::fabs(e_theta) < align_thr) {
     v_prog_ref = std::max(v_prog_ref, std::min(slow_min_speed_, v_prog_ref_free));
   }
@@ -766,7 +773,7 @@ SerestController::update_rt(NavState & nav_state)
 
   // Optional classic TiP safeguard using the same angular threshold
   {
-    const double turn_in_place_thr = (60.0 * PI / 180.0);
+    const double turn_in_place_thr = (60.0 * std::numbers::pi / 180.0);
     const double s_total = pd.s_acc.back();
     const double dist_to_end = s_total - prj.s_star;
 

--- a/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
+++ b/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
@@ -46,7 +46,7 @@ SerestController::on_initialize()
   auto node = get_node();
   const auto & ns = get_plugin_name();
 
-  // Máximos y límites básicos
+  // Maximums and basic limits
   node->declare_parameter<bool>(ns + ".allow_reverse", allow_reverse_);
   node->declare_parameter<double>(ns + ".v_progress_min", v_progress_min_);
   node->declare_parameter<double>(ns + ".k_s_share_max", k_s_share_max_);
@@ -56,7 +56,7 @@ SerestController::on_initialize()
   node->declare_parameter<double>(ns + ".max_linear_acc", max_linear_acc_);
   node->declare_parameter<double>(ns + ".max_angular_acc", max_angular_acc_);
 
-  // Seguimiento
+  // Tracking
   node->declare_parameter<double>(ns + ".k_s", k_s_);
   node->declare_parameter<double>(ns + ".k_theta", k_theta_);
   node->declare_parameter<double>(ns + ".k_y", k_y_);
@@ -64,7 +64,7 @@ SerestController::on_initialize()
   node->declare_parameter<double>(ns + ".v_ref", v_ref_);
   node->declare_parameter<double>(ns + ".eps", eps_);
 
-  // Seguridad
+  // Safety
   node->declare_parameter<double>(ns + ".a_acc", a_acc_);
   node->declare_parameter<double>(ns + ".a_brake", a_brake_);
   node->declare_parameter<double>(ns + ".a_lat_max", a_lat_max_);
@@ -73,7 +73,7 @@ SerestController::on_initialize()
   node->declare_parameter<double>(ns + ".d_hard", d_hard_);
   node->declare_parameter<double>(ns + ".t_emerg", t_emerg_);
 
-  // Blend en vértices
+  // Blend at vertices
   node->declare_parameter<double>(ns + ".blend_base", blend_base_);
   node->declare_parameter<double>(ns + ".blend_k_per_v", blend_k_per_v_);
   node->declare_parameter<double>(ns + ".kappa_max", kappa_max_);
@@ -219,29 +219,29 @@ SerestController::ref_heading_and_curvature(
     };
   auto atan2dir = [](const Vec2 & t){return std::atan2(t.y, t.x);};
 
-  // Índices de segmentos relevante: i-1, i, i + 1
+  // Relevant segment indices: i-1, i, i + 1
   const size_t i = prj.seg_idx;
   const Vec2 Ti = seg_dir(i);
   double psi_i = atan2dir(Ti);
 
-  // Mezcla local con previsualización
+  // Local blend with look-ahead
   double b = std::max(0.1, blend_base_ + blend_k_per_v_ * std::fabs(v_prev));
 
-  // Determina si estamos cerca del comienzo o fin de un segmento
+  // Determine if we are near the beginning or end of a segment
   double s_i = pd.s_acc[i];
   double s_ip1 = pd.s_acc[i + 1];
   double s = prj.s_star;
 
-  // Por defecto: rumbo constante del segmento, kappa = 0
+  // Default: constant segment heading, kappa = 0
   rk.psi_ref = psi_i;
   rk.kappa_hat = 0.0;
 
-  // Blend cerca del inicio del segmento i (con i-1)
+  // Blend near the beginning of segment i (with i-1)
   if (i > 0 && (s - s_i) < b) {
     Vec2 Tim1 = seg_dir(i - 1);
     double psi_im1 = atan2dir(Tim1);
-    double w = 1.0 / (1.0 + std::exp(-( (s - s_i) / b ))); // sigmoide en [s_i, s_i+b]
-    // Interpolación circular de rumbos
+    double w = 1.0 / (1.0 + std::exp(-( (s - s_i) / b ))); // sigmoid in [s_i, s_i+b]
+    // Circular interpolation of headings
     double sx = (1.0 - w) * std::cos(psi_im1) + w * std::cos(psi_i);
     double sy = (1.0 - w) * std::sin(psi_im1) + w * std::sin(psi_i);
     rk.psi_ref = std::atan2(sy, sx);
@@ -252,12 +252,12 @@ SerestController::ref_heading_and_curvature(
     rk.kappa_hat = std::clamp(dpsi * sigma_prime, -kappa_max_, kappa_max_);
   }
 
-  // Blend cerca del final del segmento i (hacia i + 1)
+  // Blend near the end of segment i (towards i + 1)
   if (i + 1 < pd.pts.size() - 1 && (s_ip1 - s) < b) {
     Vec2 Tip1 = seg_dir(i + 1);
     double psi_ip1 = atan2dir(Tip1);
-    double w = 1.0 / (1.0 + std::exp(-( (s_ip1 - s) / b ))); // simétrico
-    // Mezcla entre i y i + 1
+    double w = 1.0 / (1.0 + std::exp(-( (s_ip1 - s) / b ))); // symmetric
+    // Blend between i and i + 1
     double sx = (1.0 - w) * std::cos(psi_i) + w * std::cos(psi_ip1);
     double sy = (1.0 - w) * std::sin(psi_i) + w * std::sin(psi_ip1);
     rk.psi_ref = std::atan2(sy, sx);
@@ -265,7 +265,7 @@ SerestController::ref_heading_and_curvature(
     double dpsi = std::atan2(std::sin(psi_ip1 - psi_i), std::cos(psi_ip1 - psi_i));
     double sigma_prime = (w * (1 - w)) / b;
     double kappa2 = std::clamp(dpsi * sigma_prime, -kappa_max_, kappa_max_);
-    // Si hay dos blends solapados, combinamos suavemente (promedio)
+    // If there are two overlapping blends, combine smoothly (average)
     rk.kappa_hat = 0.5 * (rk.kappa_hat + kappa2);
   }
 
@@ -278,12 +278,12 @@ SerestController::frenet_errors(
   const Projection & prj, double psi_ref,
   double & e_y, double & e_theta) const
 {
-  // Vector normal a la derecha de la tangente
+  // Normal vector to the right of the tangent
   Vec2 T = v2(std::cos(psi_ref), std::sin(psi_ref));
-  Vec2 N = v2(-T.y, T.x); // 90º a la izquierda (convención)
+  Vec2 N = v2(-T.y, T.x); // 90º to the left (convention)
   Vec2 err = robot_xy - prj.closest;
 
-  e_y = dot(err, N); // distancia lateral con signo
+  e_y = dot(err, N); // signed lateral distance
   e_theta = std::atan2(std::sin(robot_yaw - psi_ref), std::cos(robot_yaw - psi_ref));
 }
 
@@ -291,16 +291,16 @@ double
 SerestController::closest_obstacle_distance(
   const NavState & nav_state) const
 {
-  // 1) Preferir medición directa si existe
+  // 1) Prefer direct measurement if it exists
   if (nav_state.has("closest_obstacle_distance")) {
     try {
       return nav_state.get<double>("closest_obstacle_distance");
     } catch (...) {
-      // continúa a estimación
+      // fall through to estimation
     }
   }
 
-  // 2) Analizar los sensores de distancia
+  // 2) Analyze distance sensors
   if (!nav_state.has("points")) {return std::numeric_limits<double>::infinity();}
 
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
@@ -325,7 +325,7 @@ SerestController::closest_obstacle_distance(
 double
 SerestController::v_safe_from_distance(double d, double slope_sin) const
 {
-  // a_eff reduce la capacidad de frenado en pendiente; en 2D slope_sin = 0
+  // a_eff reduces braking capability on slopes; in 2D slope_sin = 0
   const double a_eff = std::max(0.1, a_brake_ - 9.81 * slope_sin);
   if (d <= d0_margin_) {return 0.0;}
 
@@ -338,7 +338,7 @@ SerestController::v_safe_from_distance(double d, double slope_sin) const
 double
 SerestController::v_curvature_limit(double kappa_hat) const
 {
-  // Tres límites típicos: v_max, ω_max/|κ| y sqrt(a_lat_max/|κ|)
+  // Three typical limits: v_max, ω_max/|κ| and sqrt(a_lat_max/|κ|)
   double v1 = max_linear_speed_;
   double v2 = std::numeric_limits<double>::infinity();
   double v3 = std::numeric_limits<double>::infinity();
@@ -430,7 +430,7 @@ SerestController::safety_limits(
   d_closest = closest_obstacle_distance(nav_state);
   v_safe = v_safe_from_distance(d_closest, /*slope_sin=*/0.0);
 
-  // Límite por curvatura (versión “soft” del archivo original)
+  // Curvature-based limit ("soft" version of the original file)
   const double ak = std::fabs(rk.kappa_hat);
   double v_curv_soft = std::numeric_limits<double>::infinity();
   if (ak > 1e-6) {
@@ -465,7 +465,7 @@ SerestController::apply_corner_guard(
   alpha_corner = std::clamp(1.0 / (1.0 + penal), corner_min_alpha_, 1.0);
   omega_boost = 1.0 + corner_boost_omega_ * std::min(1.0, e_y_out / std::max(1e-3, ell_));
 
-  // Empuje al “ápice” si vas por fuera y hay curvatura
+  // Push towards the "apex" if you are outside and there is curvature
   if (std::fabs(rk.kappa_hat) > 1e-6 && e_y_out > 0.0) {
     const double e_y_des = -sgn_k * std::max(0.0, apex_ey_des_);
     const double e_y_err = e_y - e_y_des;
@@ -480,16 +480,16 @@ SerestController::should_turn_in_place(
   bool allow_reverse, double e_theta, double e_theta_goal,
   double dist_to_end, [[maybe_unused]] double turn_in_place_thr) const
 {
-  // Mantenemos compatibilidad con la firma, pero ignoramos turn_in_place_thr
-  // y usamos dos umbrales internos sin exponer parámetros.
-  const double thr_enter = 60.0 * std::numbers::pi / 180.0; // entra a girar si |e_theta| > 60°
-  // const double thr_exit = 35.0 * PI / 180.0; // sale de girar si |e_theta| < 35°
+  // Keep compatibility with the signature, but ignore turn_in_place_thr
+  // and use two internal thresholds without exposing parameters.
+  const double thr_enter = 60.0 * std::numbers::pi / 180.0; // enter TiP if |e_theta| > 60°
+  // const double thr_exit = 35.0 * PI / 180.0; // exit TiP if |e_theta| < 35°
 
-  // No permitimos “atajo” marcha atrás en esta decisión: si no permites reverse,
-  // el criterio es más estricto.
+  // Do not allow reverse "shortcut" in this decision: if reverse is not allowed,
+  // the criterion is stricter.
   bool tip = (!allow_reverse) && (std::fabs(e_theta) > thr_enter);
 
-  // Cerca del final, si el yaw al objetivo es grande, también pedimos TiP
+  // Near the end, if the yaw error to the goal is large, also request TiP
   if (dist_to_end < 0.50) {
     if (!allow_reverse && std::fabs(e_theta_goal) > thr_enter) {
       tip = true;

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -94,7 +94,8 @@ static void smooth_path(std::vector<geometry_msgs::msg::Pose> & poses, int windo
     double sum_y = 0.0;
     int count = 0;
 
-    const int begin = static_cast<int>(std::max<size_t>(0, i > static_cast<size_t>(half) ? i - half : 0));
+    const int begin = static_cast<int>(std::max<size_t>(0,
+        i > static_cast<size_t>(half) ? i - half : 0));
     const int end = static_cast<int>(std::min<size_t>(n - 1, i + half));
 
     for (int j = begin; j <= end; ++j) {

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -103,7 +103,6 @@ std::expected<void, std::string> CostmapPlanner::on_initialize()
 
 void CostmapPlanner::update(NavState & nav_state)
 {
-  current_path_.poses.clear();
   if (!nav_state.has("goals") || !nav_state.has("robot_pose") || !nav_state.has("map.dynamic")) {
     return;
   }
@@ -166,7 +165,8 @@ void CostmapPlanner::update(NavState & nav_state)
       last_plan_time = get_node()->now();
     }
     const double since_last = (get_node()->now() - last_plan_time).seconds();
-    if (continuous_replan_ && same_start_cell && same_goal_pose && since_last < 0.05) {
+    // Only allow skipping when continuous_replan_ is disabled (event-based planning)
+    if (!continuous_replan_ && same_start_cell && same_goal_pose && since_last < 0.05) {
       // Skip re-planning when nothing relevant changed recently
       nav_state.set("path", current_path_);
       return;
@@ -175,6 +175,7 @@ void CostmapPlanner::update(NavState & nav_state)
 
   auto poses = a_star_path(map, robot_pose.pose.pose, goal);
   if (!poses.empty()) {
+    current_path_.poses.clear();
     current_path_.header.stamp = get_node()->now();
     current_path_.header.frame_id = goals.header.frame_id;
     for (const auto & pose : poses) {
@@ -184,13 +185,9 @@ void CostmapPlanner::update(NavState & nav_state)
       pose_stamped.pose = pose;
       current_path_.poses.push_back(pose_stamped);
     }
-    // Publish only when the content changed (size as a cheap proxy)
-    static size_t last_published_size = 0;
-    if (current_path_.poses.size() != last_published_size) {
-      if (path_pub_->get_subscription_count() > 0) {
-        path_pub_->publish(current_path_);
-      }
-      last_published_size = current_path_.poses.size();
+    // Always publish a newly computed path
+    if (path_pub_->get_subscription_count() > 0) {
+      path_pub_->publish(current_path_);
     }
     // Update last inputs snapshot
     unsigned int sx, sy;

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -68,6 +68,48 @@ static double compute_path_length(const nav_msgs::msg::Path & path)
   return total_length;
 }
 
+// Simple path smoother: moving average over a sliding window in XY.
+// Keeps endpoints unchanged to preserve exact start and goal.
+static void smooth_path(std::vector<geometry_msgs::msg::Pose> & poses, int window_size = 5)
+{
+  if (poses.size() < 3 || window_size <= 1) {
+    return;
+  }
+
+  // Ensure window_size is odd and at least 3
+  if (window_size < 3) {
+    window_size = 3;
+  }
+  if (window_size % 2 == 0) {
+    window_size += 1;
+  }
+
+  const int half = window_size / 2;
+  const size_t n = poses.size();
+  std::vector<geometry_msgs::msg::Pose> original = poses;
+
+  // Leave first and last pose untouched
+  for (size_t i = 1; i + 1 < n; ++i) {
+    double sum_x = 0.0;
+    double sum_y = 0.0;
+    int count = 0;
+
+    const int begin = static_cast<int>(std::max<size_t>(0, i > static_cast<size_t>(half) ? i - half : 0));
+    const int end = static_cast<int>(std::min<size_t>(n - 1, i + half));
+
+    for (int j = begin; j <= end; ++j) {
+      sum_x += original[j].position.x;
+      sum_y += original[j].position.y;
+      ++count;
+    }
+
+    if (count > 0) {
+      poses[i].position.x = sum_x / static_cast<double>(count);
+      poses[i].position.y = sum_y / static_cast<double>(count);
+    }
+  }
+}
+
 CostmapPlanner::CostmapPlanner()
 {
   NavState::register_printer<nav_msgs::msg::Path>(
@@ -175,6 +217,9 @@ void CostmapPlanner::update(NavState & nav_state)
 
   auto poses = a_star_path(map, robot_pose.pose.pose, goal);
   if (!poses.empty()) {
+    // Apply a light smoothing to the raw grid path
+    smooth_path(poses);
+
     current_path_.poses.clear();
     current_path_.header.stamp = get_node()->now();
     current_path_.header.frame_id = goals.header.frame_id;


### PR DESCRIPTION
Hi,

Related to https://github.com/EasyNavigation/EasyNavigation/issues/78, this PR contains a fix to avoid path planner stops to produce paths as a result of the optimization made at #34 

This PR also contains improvements in the controllers:
- MPC fix to cope when planner is setup with `continuous_replan: false`
- MPC fix for final alignment
- Adaptation of controllers to https://github.com/EasyNavigation/EasyNavigation/pull/79, if tolerances are not set in the `nav_state`
- Path smoother for A* planner

In any case, some strange behaviors happen in MPC related to the backwards movements. It should be checked in another PR.
 