### PR TITLE
Frames fix for fusion_localizer

### DIFF
--- a/common/easynav_simple_common/src/easynav_simple_common/SimpleMap.cpp
+++ b/common/easynav_simple_common/src/easynav_simple_common/SimpleMap.cpp
@@ -296,7 +296,8 @@ SimpleMap::downsample_factor(int factor) const
         }
       }
 
-      new_map->at(x, y) = (occupied_count > (factor * factor / 2));
+      // Mark cell as occupied if any source cell in the block is occupied
+      new_map->at(x, y) = (occupied_count > 0);
     }
   }
 

--- a/common/easynav_simple_common/tests/simple_maps_tests.cpp
+++ b/common/easynav_simple_common/tests/simple_maps_tests.cpp
@@ -172,7 +172,7 @@ TEST_F(SimpleMapTest, DownsampleIntegerFactor)
   EXPECT_TRUE(downsampled->at(0, 0));
   EXPECT_FALSE(downsampled->at(1, 0));
   EXPECT_FALSE(downsampled->at(0, 1));
-  EXPECT_FALSE(downsampled->at(1, 1));
+  EXPECT_TRUE(downsampled->at(1, 1));
 }
 
 /// \brief Downsampling to new resolution
@@ -195,9 +195,9 @@ TEST_F(SimpleMapTest, DownsampleToResolution)
   EXPECT_DOUBLE_EQ(downsampled->origin_x(), -1.0);
   EXPECT_DOUBLE_EQ(downsampled->origin_y(), -1.0);
 
-  EXPECT_FALSE(downsampled->at(0, 0));
-  EXPECT_FALSE(downsampled->at(1, 1));
-  EXPECT_FALSE(downsampled->at(2, 2));
+  EXPECT_TRUE(downsampled->at(0, 0));
+  EXPECT_TRUE(downsampled->at(1, 1));
+  EXPECT_TRUE(downsampled->at(2, 2));
 }
 
 /// \brief Downsample that results in cropped edges

--- a/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
+++ b/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
@@ -23,6 +23,8 @@
 #include "easynav_mpc_controller/MPCController.hpp"
 #include "easynav_system/GoalManager.hpp"
 
+#include "easynav_common/RTTFBuffer.hpp"
+
 namespace easynav
 {
 
@@ -201,7 +203,8 @@ MPCController::update_rt(NavState & nav_state)
   const auto & last_pose = path.poses[local_horizon].pose.position;
 
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .filter({-2.0, -0.35, -1.0}, {0.0, 0.35, 1.0})
     .fuse(tf_info.map_frame)

--- a/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
+++ b/controllers/easynav_mpc_controller/src/easynav_mpc_controller/MPCController.cpp
@@ -201,9 +201,10 @@ MPCController::update_rt(NavState & nav_state)
   const auto & last_pose = path.poses[local_horizon].pose.position;
 
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & tf_info = get_tf_info();
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .filter({-2.0, -0.35, -1.0}, {0.0, 0.35, 1.0})
-    .fuse("map")
+    .fuse(tf_info.map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .collapse({NAN, NAN, 0.1})
     .downsample(0.1)

--- a/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
+++ b/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
@@ -24,6 +24,8 @@
 
 #include "easynav_mppi_controller/MPPIController.hpp"
 #include "easynav_common/types/PointPerception.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
+
 #include "easynav_system/GoalManager.hpp"
 
 #include "nav_msgs/msg/odometry.hpp"
@@ -78,7 +80,7 @@ void MPPIController::publish_mppi_markers(
   const std::vector<std::vector<std::pair<double, double>>> & all_trajs,
   const std::vector<std::pair<double, double>> & best_traj)
 {
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   visualization_msgs::msg::MarkerArray candidates;
   visualization_msgs::msg::MarkerArray optimal;
   int id = 0;
@@ -189,7 +191,7 @@ MPPIController::update_rt(NavState & nav_state)
 
   const auto & pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .filter({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0})
     .fuse(tf_info.map_frame)

--- a/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
+++ b/controllers/easynav_mppi_controller/src/easynav_mppi_controller/MPPIController.cpp
@@ -78,6 +78,7 @@ void MPPIController::publish_mppi_markers(
   const std::vector<std::vector<std::pair<double, double>>> & all_trajs,
   const std::vector<std::pair<double, double>> & best_traj)
 {
+  const auto & tf_info = get_tf_info();
   visualization_msgs::msg::MarkerArray candidates;
   visualization_msgs::msg::MarkerArray optimal;
   int id = 0;
@@ -85,7 +86,7 @@ void MPPIController::publish_mppi_markers(
   // Candidates in blue
   for (const auto & traj : all_trajs) {
     visualization_msgs::msg::Marker marker;
-    marker.header.frame_id = "map";
+    marker.header.frame_id = tf_info.map_frame;
     marker.header.stamp = rclcpp::Clock().now();
     marker.ns = "mppi_candidates";
     marker.id = id++;
@@ -110,7 +111,7 @@ void MPPIController::publish_mppi_markers(
 
   // Best trajectory in red
   visualization_msgs::msg::Marker best_marker;
-  best_marker.header.frame_id = "map";
+  best_marker.header.frame_id = tf_info.map_frame;
   best_marker.header.stamp = rclcpp::Clock().now();
   best_marker.ns = "mppi_optimal_path";
   best_marker.id = id++;
@@ -188,10 +189,10 @@ MPPIController::update_rt(NavState & nav_state)
 
   const auto & pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose").pose.pose;
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
-
+  const auto & tf_info = get_tf_info();
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .filter({-1.0, -1.0, -1.0}, {1.0, 1.0, 1.0})
-    .fuse("map")
+    .fuse(tf_info.map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .collapse({NAN, NAN, 0.1})
     .downsample(0.1)

--- a/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
+++ b/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
@@ -29,6 +29,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "easynav_common/types/PointPerception.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "easynav_serest_controller/SerestController.hpp"
 #include "pluginlib/class_list_macros.hpp"
@@ -304,9 +305,11 @@ SerestController::closest_obstacle_distance(
   if (!nav_state.has("points")) {return std::numeric_limits<double>::infinity();}
 
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(0.3)
-    .fuse(get_tf_info().robot_frame)
+    .fuse(tf_info.robot_frame)
     .filter({-dist_search_radius_, -dist_search_radius_, NAN},
       {dist_search_radius_, dist_search_radius_, 2.0})
     .collapse({NAN, NAN, 0.1})
@@ -367,8 +370,10 @@ SerestController::fetch_required_inputs(
   nav_msgs::msg::Path & path,
   nav_msgs::msg::Odometry & odom)
 {
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   if (!nav_state.has("path") || !nav_state.has("robot_pose") || !nav_state.has("map.dynamic")) {
-    publish_stop(nav_state, get_tf_info().robot_frame);
+    publish_stop(nav_state, tf_info.robot_frame);
     return false;
   }
 

--- a/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
+++ b/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
@@ -306,7 +306,7 @@ SerestController::closest_obstacle_distance(
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(0.3)
-    .fuse(get_tf_prefix() + "base_link")
+    .fuse(get_tf_info().robot_frame)
     .filter({-dist_search_radius_, -dist_search_radius_, NAN},
       {dist_search_radius_, dist_search_radius_, 2.0})
     .collapse({NAN, NAN, 0.1})
@@ -368,7 +368,7 @@ SerestController::fetch_required_inputs(
   nav_msgs::msg::Odometry & odom)
 {
   if (!nav_state.has("path") || !nav_state.has("robot_pose") || !nav_state.has("map.dynamic")) {
-    publish_stop(nav_state, "base_link");
+    publish_stop(nav_state, get_tf_info().robot_frame);
     return false;
   }
 

--- a/controllers/easynav_simple_controller/tests/simple_controller_tests.cpp
+++ b/controllers/easynav_simple_controller/tests/simple_controller_tests.cpp
@@ -144,7 +144,11 @@ TEST_F(AMCLLocalizerTest, SavemapServiceWorks)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_savemap_node");
   auto manager = std::make_shared<easynav::SimpleController>();
-  manager->initialize(node, "test_savemap");
+  easynav::TFInfo tf_info;
+  tf_info.map_frame = "world_map";
+  tf_info.odom_frame = "world_odom";
+  tf_info.robot_frame = "world_base";
+  manager->initialize(node, "test_savemap", tf_info);
 
   auto static_map = std::make_shared<easynav::SimpleMap>();
   static_map->initialize(4, 4, 0.5, -1.0, -1.0, 0);

--- a/controllers/easynav_simple_controller/tests/simple_controller_tests.cpp
+++ b/controllers/easynav_simple_controller/tests/simple_controller_tests.cpp
@@ -148,7 +148,9 @@ TEST_F(AMCLLocalizerTest, SavemapServiceWorks)
   tf_info.map_frame = "world_map";
   tf_info.odom_frame = "world_odom";
   tf_info.robot_frame = "world_base";
-  manager->initialize(node, "test_savemap", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  manager->initialize(node, "test_savemap");
 
   auto static_map = std::make_shared<easynav::SimpleMap>();
   static_map->initialize(4, 4, 0.5, -1.0, -1.0, 0);

--- a/controllers/easynav_vff_controller/src/easynav_vff_controller/VffController.cpp
+++ b/controllers/easynav_vff_controller/src/easynav_vff_controller/VffController.cpp
@@ -64,7 +64,7 @@ std::expected<void, std::string> VffController::on_initialize()
 
   // Initialize the odometry message
   cmd_vel_.header.stamp = node->now();
-  cmd_vel_.header.frame_id = get_tf_prefix() + "base_link";
+  cmd_vel_.header.frame_id = get_tf_info().robot_frame;
   cmd_vel_.twist.linear.x = 0.0;
   cmd_vel_.twist.linear.y = 0.0;
   cmd_vel_.twist.linear.z = 0.0;
@@ -215,7 +215,7 @@ void VffController::update_rt(NavState & nav_state)
   const auto & all_goals = nav_state.get<nav_msgs::msg::Goals>("goals");
 
   if (all_goals.goals.empty()) {
-    cmd_vel_.header.frame_id = get_tf_prefix() + "map";
+    cmd_vel_.header.frame_id = get_tf_info().map_frame;
     cmd_vel_.header.stamp = get_node()->now();
     cmd_vel_.twist.linear.x = 0.0;
     cmd_vel_.twist.angular.z = 0.0;
@@ -259,17 +259,18 @@ void VffController::update_rt(NavState & nav_state)
 
     const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
+    const auto & tf_info = get_tf_info();
     auto fused =
       PointPerceptionsOpsView(perceptions)
       .filter({-10.0, -10.0, -10.0}, {10.0, 10.0, 10.0})
-      .fuse(get_tf_prefix() + "base_link")
+      .fuse(tf_info.robot_frame)
       .filter({obstacle_detection_x_min_, obstacle_detection_y_min_, obstacle_detection_z_min_},
         {obstacle_detection_x_max_, obstacle_detection_y_max_,
           obstacle_detection_z_max_})
       .as_points();
 
     // Get VFF vectors
-    const VFFVectors & vff = get_vff(angle_error, fused, get_tf_prefix() + "base_link");
+    const VFFVectors & vff = get_vff(angle_error, fused, tf_info.robot_frame);
 
     // Use result vector to calculate output speed
     const auto & v = vff.result;

--- a/controllers/easynav_vff_controller/src/easynav_vff_controller/VffController.cpp
+++ b/controllers/easynav_vff_controller/src/easynav_vff_controller/VffController.cpp
@@ -62,9 +62,11 @@ std::expected<void, std::string> VffController::on_initialize()
   node->get_parameter<double>(plugin_name + ".max_speed", max_speed_);
   node->get_parameter<double>(plugin_name + ".max_angular_speed", max_angular_speed_);
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   // Initialize the odometry message
   cmd_vel_.header.stamp = node->now();
-  cmd_vel_.header.frame_id = get_tf_info().robot_frame;
+  cmd_vel_.header.frame_id = tf_info.robot_frame;
   cmd_vel_.twist.linear.x = 0.0;
   cmd_vel_.twist.linear.y = 0.0;
   cmd_vel_.twist.linear.z = 0.0;
@@ -213,9 +215,10 @@ void VffController::update_rt(NavState & nav_state)
   if (!nav_state.has("robot_pose")) {return;}
 
   const auto & all_goals = nav_state.get<nav_msgs::msg::Goals>("goals");
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
   if (all_goals.goals.empty()) {
-    cmd_vel_.header.frame_id = get_tf_info().map_frame;
+    cmd_vel_.header.frame_id = tf_info.map_frame;
     cmd_vel_.header.stamp = get_node()->now();
     cmd_vel_.twist.linear.x = 0.0;
     cmd_vel_.twist.angular.z = 0.0;
@@ -259,7 +262,7 @@ void VffController::update_rt(NavState & nav_state)
 
     const auto & perceptions = nav_state.get<PointPerceptions>("points");
 
-    const auto & tf_info = get_tf_info();
+    const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
     auto fused =
       PointPerceptionsOpsView(perceptions)
       .filter({-10.0, -10.0, -10.0}, {10.0, 10.0, 10.0})

--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -340,7 +340,7 @@ AMCLLocalizer::init_pose_callback(
   auto logger = get_node()->get_logger();
 
   // Check expected frame
-  const std::string expected_frame = get_tf_prefix() + std::string("map");
+  const std::string expected_frame = get_tf_info().map_frame;
   if (!msg->header.frame_id.empty() && msg->header.frame_id != expected_frame) {
     RCLCPP_WARN(
       logger,
@@ -578,9 +578,10 @@ AMCLLocalizer::correct(NavState & nav_state)
 
   const auto & map_static = nav_state.get<Costmap2D>("map.static");
 
+  const auto & tf_info = get_tf_info();
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .downsample(map_static.getResolution())
-    .fuse(get_tf_prefix() + "base_footprint")
+    .fuse(tf_info.robot_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .collapse({NAN, NAN, 0.1})
     .downsample(map_static.getResolution())
@@ -717,8 +718,9 @@ AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
 {
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  tf_msg.header.frame_id = get_tf_prefix() + "map";
-  tf_msg.child_frame_id = get_tf_prefix() + "odom";
+  const auto & tf_info = get_tf_info();
+  tf_msg.header.frame_id = tf_info.map_frame;
+  tf_msg.child_frame_id = tf_info.odom_frame;
   tf_msg.transform = tf2::toMsg(map2bf);
 
   RTTFBuffer::getInstance()->setTransform(tf_msg, "easynav", false);
@@ -730,7 +732,7 @@ AMCLLocalizer::publishParticles()
 {
   geometry_msgs::msg::PoseArray array_msg;
   array_msg.header.stamp = get_node()->now();
-  array_msg.header.frame_id = get_tf_prefix() + "map";
+  array_msg.header.frame_id = get_tf_info().map_frame;
 
   array_msg.poses.reserve(particles_.size());
   for (const auto & p : particles_) {
@@ -791,7 +793,7 @@ AMCLLocalizer::publishEstimatedPose(const tf2::Transform & est_pose)
 
   geometry_msgs::msg::PoseWithCovarianceStamped msg;
   msg.header.stamp = get_node()->now();
-  msg.header.frame_id = get_tf_prefix() + "map";
+  msg.header.frame_id = get_tf_info().map_frame;
 
   msg.pose.pose.position.x = mean.x();
   msg.pose.pose.position.y = mean.y();
@@ -814,8 +816,9 @@ AMCLLocalizer::get_pose()
   nav_msgs::msg::Odometry odom_msg;
 
   odom_msg.header.stamp = get_node()->now();
-  odom_msg.header.frame_id = get_tf_prefix() + "map";
-  odom_msg.child_frame_id = get_tf_prefix() + "base_footprint";
+  const auto & tf_info = get_tf_info();
+  odom_msg.header.frame_id = tf_info.map_frame;
+  odom_msg.child_frame_id = tf_info.robot_frame;
 
   tf2::Transform est_pose = getEstimatedPose();
 

--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -338,9 +338,9 @@ AMCLLocalizer::init_pose_callback(
   }
 
   auto logger = get_node()->get_logger();
-
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   // Check expected frame
-  const std::string expected_frame = get_tf_info().map_frame;
+  const std::string expected_frame = tf_info.map_frame;
   if (!msg->header.frame_id.empty() && msg->header.frame_id != expected_frame) {
     RCLCPP_WARN(
       logger,
@@ -485,10 +485,12 @@ AMCLLocalizer::init_pose_callback(
 void
 AMCLLocalizer::update_odom_from_tf()
 {
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   geometry_msgs::msg::TransformStamped tf_msg;
   try {
     tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-      get_tf_info().odom_frame, get_tf_info().robot_frame, tf2::TimePointZero,
+      tf_info.odom_frame, tf_info.robot_frame, tf2::TimePointZero,
         tf2::durationFromSec(0.0));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN(get_node()->get_logger(), "AMCLLocalizer::update: TF failed: %s", ex.what());
@@ -579,7 +581,7 @@ AMCLLocalizer::correct(NavState & nav_state)
 
   const auto & map_static = nav_state.get<Costmap2D>("map.static");
 
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .downsample(map_static.getResolution())
     .fuse(tf_info.robot_frame)
@@ -719,7 +721,7 @@ AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
 {
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   tf_msg.header.frame_id = tf_info.map_frame;
   tf_msg.child_frame_id = tf_info.odom_frame;
   tf_msg.transform = tf2::toMsg(map2bf);
@@ -731,10 +733,11 @@ AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
 void
 AMCLLocalizer::publishParticles()
 {
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   geometry_msgs::msg::PoseArray array_msg;
   array_msg.header.stamp = get_node()->now();
-  array_msg.header.frame_id = get_tf_info().map_frame;
-
+  array_msg.header.frame_id = tf_info.map_frame;
   array_msg.poses.reserve(particles_.size());
   for (const auto & p : particles_) {
     geometry_msgs::msg::Pose pose_msg;
@@ -792,9 +795,10 @@ AMCLLocalizer::publishEstimatedPose(const tf2::Transform & est_pose)
   tf2::Matrix3x3 cov = computeCovariance(particles_, 0, N_top, mean);
   double yaw_variance = computeYawVariance(particles_, 0, N_top);
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   geometry_msgs::msg::PoseWithCovarianceStamped msg;
   msg.header.stamp = get_node()->now();
-  msg.header.frame_id = get_tf_info().map_frame;
+  msg.header.frame_id = tf_info.map_frame;
 
   msg.pose.pose.position.x = mean.x();
   msg.pose.pose.position.y = mean.y();
@@ -817,7 +821,7 @@ AMCLLocalizer::get_pose()
   nav_msgs::msg::Odometry odom_msg;
 
   odom_msg.header.stamp = get_node()->now();
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   odom_msg.header.frame_id = tf_info.map_frame;
   odom_msg.child_frame_id = tf_info.robot_frame;
 

--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -488,7 +488,8 @@ AMCLLocalizer::update_odom_from_tf()
   geometry_msgs::msg::TransformStamped tf_msg;
   try {
     tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-      "odom", "base_footprint", tf2::TimePointZero, tf2::durationFromSec(0.0));
+      get_tf_info().odom_frame, get_tf_info().robot_frame, tf2::TimePointZero,
+        tf2::durationFromSec(0.0));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN(get_node()->get_logger(), "AMCLLocalizer::update: TF failed: %s", ex.what());
     return;

--- a/localizers/easynav_fusion_localizer/include/easynav_fusion_localizer/FusionLocalizer.hpp
+++ b/localizers/easynav_fusion_localizer/include/easynav_fusion_localizer/FusionLocalizer.hpp
@@ -55,10 +55,6 @@ private:
   int n_imu_sensors_{0};
   int n_gps_sensors_{0};
 
-  std::string base_link_frame_id_;
-  std::string odom_frame_id_;
-  std::string world_frame_id_;
-
   geometry_msgs::msg::PoseWithCovarianceStamped
   navsatfix_to_pose(const sensor_msgs::msg::NavSatFix & navsat_msg);
 

--- a/localizers/easynav_fusion_localizer/include/easynav_fusion_localizer/ukf_wrapper.hpp
+++ b/localizers/easynav_fusion_localizer/include/easynav_fusion_localizer/ukf_wrapper.hpp
@@ -50,7 +50,7 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "easynav_common/types/TFInfo.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 #include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -206,12 +206,6 @@ public:
   robot_localization::Ukf & getFilter()
   {
     return filter_;
-  }
-
-  //! @brief Returns TF configuration (map, odom, robot frames)
-  const easynav::TFInfo & getTFInfo() const
-  {
-    return tf_info_;
   }
 
   //! @brief Retrieves the EKF's output for broadcasting
@@ -626,9 +620,6 @@ protected:
   //! node will calculate and broadcast.
   //!
   std::string world_frame_id_;
-
-  //! @brief TF configuration aggregated for Easynav
-  easynav::TFInfo tf_info_;
 
   //! @brief Used for outputting debug messages
   //!

--- a/localizers/easynav_fusion_localizer/include/easynav_fusion_localizer/ukf_wrapper.hpp
+++ b/localizers/easynav_fusion_localizer/include/easynav_fusion_localizer/ukf_wrapper.hpp
@@ -50,6 +50,7 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
+#include "easynav_common/types/TFInfo.hpp"
 #include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -207,6 +208,12 @@ public:
     return filter_;
   }
 
+  //! @brief Returns TF configuration (map, odom, robot frames)
+  const easynav::TFInfo & getTFInfo() const
+  {
+    return tf_info_;
+  }
+
   //! @brief Retrieves the EKF's output for broadcasting
   //! @param[out] message - The standard ROS odometry message to be filled
   //! @return true if the filter is initialized, false otherwise
@@ -346,21 +353,6 @@ public:
   std::vector<CallbackData> getGpsCallbackDataArr() const
   {
     return gps_callbackData_arr_;
-  }
-
-  std::string getBaseLinkFrameId() const
-  {
-    return base_link_frame_id_;
-  }
-
-  std::string getWorldFrameId() const
-  {
-    return world_frame_id_;
-  }
-
-  std::string getOdomFrameId() const
-  {
-    return odom_frame_id_;
   }
 
 protected:
@@ -634,6 +626,9 @@ protected:
   //! node will calculate and broadcast.
   //!
   std::string world_frame_id_;
+
+  //! @brief TF configuration aggregated for Easynav
+  easynav::TFInfo tf_info_;
 
   //! @brief Used for outputting debug messages
   //!

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
@@ -28,7 +28,8 @@ std::expected<void, std::string> FusionLocalizer::on_initialize()
     last_gps_stamp_.resize(10, 0.0);
 
     const std::string & plugin_name = this->get_plugin_name();
-    const auto & tf_info = this->get_tf_info();
+    const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
     RCLCPP_INFO(localizer_node->get_logger(), "Using tf_prefix: '%s'", tf_info.tf_prefix.c_str());
     RCLCPP_INFO(localizer_node->get_logger(), "Using parameter namespace: '%s'",
     plugin_name.c_str());
@@ -82,7 +83,7 @@ void FusionLocalizer::update_rt(NavState & nav_state)
         auto pose = navsatfix_to_pose(gps_data[i]->data);
         // nav_state.set("UTM_gnss_pose", pose);
         // Call the wrapper callback
-        const auto & tf_info = get_tf_info();
+        const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
         ukf_wrapper_->poseCallback(
           std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>(pose),
           ukf_wrapper_->getGpsCallbackDataArr()[i], // callback_data
@@ -112,12 +113,13 @@ geometry_msgs::msg::PoseWithCovarianceStamped FusionLocalizer::navsatfix_to_pose
   const sensor_msgs::msg::NavSatFix & navsat_msg)
 {
   geometry_msgs::msg::PoseWithCovarianceStamped pose_msg;
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
   // 1. Establecer el Header
   // Usamos el mismo timestamp que el mensaje original
   // y el world_frame_id que el filtro UKF espera (p.ej., "map" u "odom")
   pose_msg.header = navsat_msg.header;
-  pose_msg.header.frame_id = get_tf_info().world_frame;
+  pose_msg.header.frame_id = tf_info.world_frame;
 
   // 2. Convertir coordenadas (Lat, Lon) a UTM (x, y)
   double utm_x, utm_y;

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
@@ -86,7 +86,7 @@ void FusionLocalizer::update_rt(NavState & nav_state)
         ukf_wrapper_->poseCallback(
           std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>(pose),
           ukf_wrapper_->getGpsCallbackDataArr()[i], // callback_data
-          tf_info.world_frame, // target_frame
+          tf_info.map_frame, // target_frame
           tf_info.odom_frame,  // pose_source_frame
           false                           // imu_data
         );
@@ -117,7 +117,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped FusionLocalizer::navsatfix_to_pose
   // Usamos el mismo timestamp que el mensaje original
   // y el world_frame_id que el filtro UKF espera (p.ej., "map" u "odom")
   pose_msg.header = navsat_msg.header;
-  pose_msg.header.frame_id = get_tf_info().world_frame;
+  pose_msg.header.frame_id = get_tf_info().map_frame;
 
   // 2. Convertir coordenadas (Lat, Lon) a UTM (x, y)
   double utm_x, utm_y;

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
@@ -120,7 +120,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped FusionLocalizer::navsatfix_to_pose
   // y el world_frame_id que el filtro UKF espera (p.ej., "map" u "odom")
   pose_msg.header = navsat_msg.header;
 
-  pose_msg.header.frame_id = get_tf_info().map_frame;
+  pose_msg.header.frame_id = tf_info.map_frame;
 
   // 2. Convertir coordenadas (Lat, Lon) a UTM (x, y)
   double utm_x, utm_y;

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/FusionLocalizer.cpp
@@ -28,13 +28,13 @@ std::expected<void, std::string> FusionLocalizer::on_initialize()
     last_gps_stamp_.resize(10, 0.0);
 
     const std::string & plugin_name = this->get_plugin_name();
-    const std::string & tf_prefix = this->get_tf_prefix();
-    RCLCPP_INFO(localizer_node->get_logger(), "Using tf_prefix: '%s'", tf_prefix.c_str());
+    const auto & tf_info = this->get_tf_info();
+    RCLCPP_INFO(localizer_node->get_logger(), "Using tf_prefix: '%s'", tf_info.tf_prefix.c_str());
     RCLCPP_INFO(localizer_node->get_logger(), "Using parameter namespace: '%s'",
     plugin_name.c_str());
 
     ukf_wrapper_ = std::make_unique<robot_localization::UkfWrapper>(
-      localizer_node, tf_prefix, plugin_name + ".local_filter"
+      localizer_node, tf_info.tf_prefix, plugin_name + ".local_filter"
     );
     ukf_wrapper_->initialize();
     localizer_node->declare_parameter(plugin_name + ".latitude_origin", double(0.0));
@@ -64,10 +64,6 @@ std::expected<void, std::string> FusionLocalizer::on_initialize()
 
   n_gps_sensors_ = static_cast<int>(ukf_wrapper_->getGpsCallbackDataArr().size());
 
-  base_link_frame_id_ = ukf_wrapper_->getBaseLinkFrameId();
-  world_frame_id_ = ukf_wrapper_->getWorldFrameId();
-  odom_frame_id_ = ukf_wrapper_->getOdomFrameId();
-
   RCLCPP_INFO(get_node()->get_logger(), "FusionLocalizer (UKF) initialized successfully.");
   return {};
 }
@@ -86,11 +82,12 @@ void FusionLocalizer::update_rt(NavState & nav_state)
         auto pose = navsatfix_to_pose(gps_data[i]->data);
         // nav_state.set("UTM_gnss_pose", pose);
         // Call the wrapper callback
+        const auto & tf_info = get_tf_info();
         ukf_wrapper_->poseCallback(
           std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>(pose),
           ukf_wrapper_->getGpsCallbackDataArr()[i], // callback_data
-          ukf_wrapper_->getWorldFrameId(), // target_frame
-          ukf_wrapper_->getOdomFrameId(),  // pose_source_frame
+          tf_info.world_frame, // target_frame
+          tf_info.odom_frame,  // pose_source_frame
           false                           // imu_data
         );
       }
@@ -120,7 +117,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped FusionLocalizer::navsatfix_to_pose
   // Usamos el mismo timestamp que el mensaje original
   // y el world_frame_id que el filtro UKF espera (p.ej., "map" u "odom")
   pose_msg.header = navsat_msg.header;
-  pose_msg.header.frame_id = world_frame_id_;
+  pose_msg.header.frame_id = get_tf_info().world_frame;
 
   // 2. Convertir coordenadas (Lat, Lon) a UTM (x, y)
   double utm_x, utm_y;

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
@@ -894,7 +894,8 @@ void UkfWrapper::loadParams()
   map_frame_id_ = tf_info.map_frame;
   odom_frame_id_ = tf_info.odom_frame;
   base_link_frame_id_ = tf_info.robot_frame;
-  world_frame_id_ = tf_info.world_frame;
+  // World frame comes from Easynav TFInfo configuration
+  world_frame_id_ = tf_info_.map_frame;
 
   base_link_output_frame_id_ = base_link_frame_id_;
 
@@ -924,8 +925,6 @@ void UkfWrapper::loadParams()
    * The default is the latter behavior (broadcast of odom->base_link).
    */
 
-  // World frame comes from Easynav TFInfo configuration
-  world_frame_id_ = tf_info_.map_frame;
 
 
   if (map_frame_id_ == odom_frame_id_ ||

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
@@ -908,7 +908,7 @@ void UkfWrapper::loadParams()
    * transform to compute *and broadcast* map->odom.
    *
    * The state estimation nodes in robot_localization therefore have two
-   * "modes." If your world_frame parameter value matches the odom_frame
+   * "modes." If your world_frame parameter value matches the map_frame
    * parameter value, then robot_localization will assume someone else is
    * broadcasting a transform from odom_frame->base_link_frame, and it will
    * compute the map_frame->odom_frame transform. Otherwise, it will simply
@@ -917,7 +917,7 @@ void UkfWrapper::loadParams()
    * The default is the latter behavior (broadcast of odom->base_link).
    */
   // World frame comes from Easynav TFInfo configuration
-  world_frame_id_ = tf_info_.world_frame;
+  world_frame_id_ = tf_info_.map_frame;
 
   if (map_frame_id_ == odom_frame_id_ ||
     odom_frame_id_ == base_link_frame_id_ ||

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
@@ -895,7 +895,7 @@ void UkfWrapper::loadParams()
   odom_frame_id_ = tf_info.odom_frame;
   base_link_frame_id_ = tf_info.robot_frame;
   // World frame comes from Easynav TFInfo configuration
-  world_frame_id_ = tf_info_.map_frame;
+  world_frame_id_ = tf_info.map_frame;
 
   base_link_output_frame_id_ = base_link_frame_id_;
 

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
@@ -77,6 +77,8 @@
 #include <tf2_ros/transform_broadcaster.hpp>
 #include <tf2_ros/transform_listener.hpp>
 
+#include "easynav_common/RTTFBuffer.hpp"
+
 namespace robot_localization
 {
 using namespace std::chrono_literals;
@@ -886,9 +888,14 @@ void UkfWrapper::loadParams()
   }
 
   // Frame configuration comes from Easynav TFInfo; no frame params declared here
-  map_frame_id_ = tf_info_.map_frame;
-  odom_frame_id_ = tf_info_.odom_frame;
-  base_link_frame_id_ = tf_info_.robot_frame;
+
+  const auto & tf_info = easynav::RTTFBuffer::getInstance()->get_tf_info();
+
+  map_frame_id_ = tf_info.map_frame;
+  odom_frame_id_ = tf_info.odom_frame;
+  base_link_frame_id_ = tf_info.robot_frame;
+  world_frame_id_ = tf_info.world_frame;
+
   base_link_output_frame_id_ = base_link_frame_id_;
 
   /*
@@ -916,8 +923,6 @@ void UkfWrapper::loadParams()
    *
    * The default is the latter behavior (broadcast of odom->base_link).
    */
-  // World frame comes from Easynav TFInfo configuration
-  world_frame_id_ = tf_info_.world_frame;
 
   if (map_frame_id_ == odom_frame_id_ ||
     odom_frame_id_ == base_link_frame_id_ ||

--- a/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
+++ b/localizers/easynav_fusion_localizer/src/easynav_fusion_localizer/ukf_wrapper.cpp
@@ -885,17 +885,11 @@ void UkfWrapper::loadParams()
     }
   }
 
-  // These params specify the name of the robot's body frame (typically
-  // base_link) and odometry frame (typically odom)
-  map_frame_id_ = parent_node_->declare_parameter(param_prefix + "map_frame", std::string("map"));
-  odom_frame_id_ = parent_node_->declare_parameter(param_prefix + "odom_frame",
-      std::string("odom"));
-  base_link_frame_id_ = parent_node_->declare_parameter(param_prefix +
-    "base_link_frame",
-    std::string("base_link"));
-  base_link_output_frame_id_ = parent_node_->declare_parameter(param_prefix +
-    "base_link_frame_output",
-    base_link_frame_id_);
+  // Frame configuration comes from Easynav TFInfo; no frame params declared here
+  map_frame_id_ = tf_info_.map_frame;
+  odom_frame_id_ = tf_info_.odom_frame;
+  base_link_frame_id_ = tf_info_.robot_frame;
+  base_link_output_frame_id_ = base_link_frame_id_;
 
   /*
    * These parameters are designed to enforce compliance with REP-105:
@@ -922,7 +916,8 @@ void UkfWrapper::loadParams()
    *
    * The default is the latter behavior (broadcast of odom->base_link).
    */
-  world_frame_id_ = parent_node_->declare_parameter(param_prefix + "world_frame", odom_frame_id_);
+  // World frame comes from Easynav TFInfo configuration
+  world_frame_id_ = tf_info_.world_frame;
 
   if (map_frame_id_ == odom_frame_id_ ||
     odom_frame_id_ == base_link_frame_id_ ||

--- a/localizers/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
+++ b/localizers/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
@@ -34,8 +34,9 @@ std::expected<void, std::string> GpsLocalizer::on_initialize()
 
   // Initialize the odometry message
   odom_.header.stamp = get_node()->now();
-  odom_.header.frame_id = get_tf_prefix() + "map";
-  odom_.child_frame_id = get_tf_prefix() + "base_link";
+  const auto & tf_info = get_tf_info();
+  odom_.header.frame_id = tf_info.map_frame;
+  odom_.child_frame_id = tf_info.robot_frame;
 
   // Create subscriber to GPS data
   gps_subscriber_ = node->create_subscription<sensor_msgs::msg::NavSatFix>(
@@ -57,8 +58,8 @@ std::expected<void, std::string> GpsLocalizer::on_initialize()
   // Create static transform
   geometry_msgs::msg::TransformStamped transform;
   transform.header.stamp = node->now();
-  transform.header.frame_id = get_tf_prefix() + "map";
-  transform.child_frame_id = get_tf_prefix() + "odom";
+  transform.header.frame_id = tf_info.map_frame;
+  transform.child_frame_id = tf_info.odom_frame;
   transform.transform.translation.x = 0.0;
   transform.transform.translation.y = 0.0;
   transform.transform.translation.z = 0.0;
@@ -114,8 +115,9 @@ void GpsLocalizer::update(NavState & nav_state)
 
   // Get XY cartesian coordinates respect to the origin
   odom_.header.stamp = gps_msg_.header.stamp;
-  odom_.header.frame_id = get_tf_prefix() + "map";
-  odom_.child_frame_id = get_tf_prefix() + "base_link";
+  const auto & tf_info = get_tf_info();
+  odom_.header.frame_id = tf_info.map_frame;
+  odom_.child_frame_id = tf_info.robot_frame;
   odom_.pose.pose.position.x = utm_x - origin_utm_.x;
   odom_.pose.pose.position.y = utm_y - origin_utm_.y;
 

--- a/localizers/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
+++ b/localizers/easynav_gps_localizer/src/easynav_gps_localizer/GpsLocalizer.cpp
@@ -34,7 +34,7 @@ std::expected<void, std::string> GpsLocalizer::on_initialize()
 
   // Initialize the odometry message
   odom_.header.stamp = get_node()->now();
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   odom_.header.frame_id = tf_info.map_frame;
   odom_.child_frame_id = tf_info.robot_frame;
 
@@ -115,7 +115,7 @@ void GpsLocalizer::update(NavState & nav_state)
 
   // Get XY cartesian coordinates respect to the origin
   odom_.header.stamp = gps_msg_.header.stamp;
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   odom_.header.frame_id = tf_info.map_frame;
   odom_.child_frame_id = tf_info.robot_frame;
   odom_.pose.pose.position.x = utm_x - origin_utm_.x;

--- a/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
@@ -484,7 +484,8 @@ void AMCLLocalizer::update_odom_from_tf()
   geometry_msgs::msg::TransformStamped tf_msg;
   try {
     tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-      "odom", "base_footprint", tf2::TimePointZero, tf2::durationFromSec(0.0));
+     get_tf_info().odom_frame, get_tf_info().robot_frame, tf2::TimePointZero,
+          tf2::durationFromSec(0.0));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN(get_node()->get_logger(), "TF failed: %s", ex.what());
     return;
@@ -620,12 +621,14 @@ static inline std::string get_frame_id_from(const PointPerception & pp)
 }
 
 
-static inline tf2::Transform lookup_bf_to_sensor(const std::string & sensor_frame)
+static inline tf2::Transform lookup_bf_to_sensor(
+  const std::string & robot_frame,
+  const std::string & sensor_frame)
 {
   if (sensor_frame.empty()) {return tf2::Transform::getIdentity();}
   geometry_msgs::msg::TransformStamped tf_msg =
     RTTFBuffer::getInstance()->lookupTransform(
-      "base_footprint", sensor_frame, tf2::TimePointZero, tf2::durationFromSec(0.0));
+      robot_frame, sensor_frame, tf2::TimePointZero, tf2::durationFromSec(0.0));
   tf2::Transform T; tf2::fromMsg(tf_msg.transform, T);
   return T;
 }
@@ -744,7 +747,7 @@ void AMCLLocalizer::correct(NavState & nav_state)
   for (const auto & b : bundles) {
     if (!T_bf_sensor_cache.count(b.frame_id)) {
       try {
-        T_bf_sensor_cache[b.frame_id] = lookup_bf_to_sensor(b.frame_id);
+        T_bf_sensor_cache[b.frame_id] = lookup_bf_to_sensor(get_tf_info().robot_frame, b.frame_id);
 
         // const tf2::Transform & t = T_bf_sensor_cache[b.frame_id];
 

--- a/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
@@ -954,8 +954,9 @@ void AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
   }
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  tf_msg.header.frame_id = get_tf_prefix() + "map";
-  tf_msg.child_frame_id = get_tf_prefix() + "odom";
+  const auto & tf_info = get_tf_info();
+  tf_msg.header.frame_id = tf_info.map_frame;
+  tf_msg.child_frame_id = tf_info.odom_frame;
   tf_msg.transform = tf2::toMsg(map2bf);
   RTTFBuffer::getInstance()->setTransform(tf_msg, "easynav", false);
   tf_broadcaster_->sendTransform(tf_msg);
@@ -965,7 +966,7 @@ void AMCLLocalizer::publishParticles()
 {
   geometry_msgs::msg::PoseArray array_msg;
   array_msg.header.stamp = get_node()->now();
-  array_msg.header.frame_id = get_tf_prefix() + "map";
+  array_msg.header.frame_id = get_tf_info().map_frame;
   array_msg.poses.reserve(particles_.size());
   for (const auto & p : particles_) {
     geometry_msgs::msg::Pose pose_msg;
@@ -1059,7 +1060,7 @@ AMCLLocalizer::publishEstimatedPose(const tf2::Transform & est_pose)
 
   geometry_msgs::msg::PoseWithCovarianceStamped msg;
   msg.header.stamp = get_node()->now();
-  msg.header.frame_id = get_tf_prefix() + "map";
+  msg.header.frame_id = get_tf_info().map_frame;
 
   msg.pose.pose.position.x = mean.x();
   msg.pose.pose.position.y = mean.y();
@@ -1082,8 +1083,9 @@ AMCLLocalizer::get_pose()
 {
   nav_msgs::msg::Odometry odom_msg;
   odom_msg.header.stamp = get_node()->now();
-  odom_msg.header.frame_id = get_tf_prefix() + "map";
-  odom_msg.child_frame_id = get_tf_prefix() + "base_footprint";
+  const auto & tf_info = get_tf_info();
+  odom_msg.header.frame_id = tf_info.map_frame;
+  odom_msg.child_frame_id = tf_info.robot_frame;
 
   pose_ = getEstimatedPose();
   tf2::Transform est_pose = pose_;

--- a/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_navmap_localizer/src/easynav_navmap_localizer/AMCLLocalizer.cpp
@@ -481,10 +481,12 @@ void AMCLLocalizer::odom_callback(nav_msgs::msg::Odometry::UniquePtr msg)
 
 void AMCLLocalizer::update_odom_from_tf()
 {
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   geometry_msgs::msg::TransformStamped tf_msg;
   try {
     tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-     get_tf_info().odom_frame, get_tf_info().robot_frame, tf2::TimePointZero,
+     tf_info.odom_frame, tf_info.robot_frame, tf2::TimePointZero,
           tf2::durationFromSec(0.0));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN(get_node()->get_logger(), "TF failed: %s", ex.what());
@@ -746,8 +748,9 @@ void AMCLLocalizer::correct(NavState & nav_state)
   T_bf_sensor_cache.reserve(bundles.size());
   for (const auto & b : bundles) {
     if (!T_bf_sensor_cache.count(b.frame_id)) {
+      const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
       try {
-        T_bf_sensor_cache[b.frame_id] = lookup_bf_to_sensor(get_tf_info().robot_frame, b.frame_id);
+        T_bf_sensor_cache[b.frame_id] = lookup_bf_to_sensor(tf_info.robot_frame, b.frame_id);
 
         // const tf2::Transform & t = T_bf_sensor_cache[b.frame_id];
 
@@ -957,7 +960,7 @@ void AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
   }
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   tf_msg.header.frame_id = tf_info.map_frame;
   tf_msg.child_frame_id = tf_info.odom_frame;
   tf_msg.transform = tf2::toMsg(map2bf);
@@ -967,9 +970,11 @@ void AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
 
 void AMCLLocalizer::publishParticles()
 {
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   geometry_msgs::msg::PoseArray array_msg;
   array_msg.header.stamp = get_node()->now();
-  array_msg.header.frame_id = get_tf_info().map_frame;
+  array_msg.header.frame_id = tf_info.map_frame;
   array_msg.poses.reserve(particles_.size());
   for (const auto & p : particles_) {
     geometry_msgs::msg::Pose pose_msg;
@@ -1061,9 +1066,11 @@ AMCLLocalizer::publishEstimatedPose(const tf2::Transform & est_pose)
   tf2::Matrix3x3 cov = computeCovariance(top_particles, 0, top_particles.size(), mean);
   double yaw_var = computeYawVariance(top_particles, 0, top_particles.size());
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   geometry_msgs::msg::PoseWithCovarianceStamped msg;
   msg.header.stamp = get_node()->now();
-  msg.header.frame_id = get_tf_info().map_frame;
+  msg.header.frame_id = tf_info.map_frame;
 
   msg.pose.pose.position.x = mean.x();
   msg.pose.pose.position.y = mean.y();
@@ -1086,7 +1093,7 @@ AMCLLocalizer::get_pose()
 {
   nav_msgs::msg::Odometry odom_msg;
   odom_msg.header.stamp = get_node()->now();
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   odom_msg.header.frame_id = tf_info.map_frame;
   odom_msg.child_frame_id = tf_info.robot_frame;
 

--- a/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
@@ -386,9 +386,10 @@ void AMCLLocalizer::correct(NavState & nav_state)
 
   const auto & map_static = nav_state.get<SimpleMap>("map.static");
 
+  const auto & tf_info = get_tf_info();
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .downsample(map_static.resolution())
-    .fuse(get_tf_prefix() + "base_footprint")
+    .fuse(tf_info.robot_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .collapse({NAN, NAN, 0.1})
     .downsample(map_static.resolution())
@@ -526,8 +527,9 @@ AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
 {
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  tf_msg.header.frame_id = get_tf_prefix() + "map";
-  tf_msg.child_frame_id = get_tf_prefix() + "odom";
+  const auto & tf_info = get_tf_info();
+  tf_msg.header.frame_id = tf_info.map_frame;
+  tf_msg.child_frame_id = tf_info.odom_frame;
   tf_msg.transform = tf2::toMsg(map2bf);
 
   RTTFBuffer::getInstance()->setTransform(tf_msg, "easynav", false);
@@ -539,7 +541,7 @@ AMCLLocalizer::publishParticles()
 {
   geometry_msgs::msg::PoseArray array_msg;
   array_msg.header.stamp = get_node()->now();
-  array_msg.header.frame_id = get_tf_prefix() + "map";
+  array_msg.header.frame_id = get_tf_info().map_frame;
 
   array_msg.poses.reserve(particles_.size());
   for (const auto & p : particles_) {
@@ -600,7 +602,7 @@ AMCLLocalizer::publishEstimatedPose(const tf2::Transform & est_pose)
 
   geometry_msgs::msg::PoseWithCovarianceStamped msg;
   msg.header.stamp = get_node()->now();
-  msg.header.frame_id = get_tf_prefix() + "map";
+  msg.header.frame_id = get_tf_info().map_frame;
 
   msg.pose.pose.position.x = mean.x();
   msg.pose.pose.position.y = mean.y();
@@ -623,8 +625,9 @@ AMCLLocalizer::get_pose()
   nav_msgs::msg::Odometry odom_msg;
 
   odom_msg.header.stamp = get_node()->now();
-  odom_msg.header.frame_id = get_tf_prefix() + "map";
-  odom_msg.child_frame_id = get_tf_prefix() + "base_footprint";
+  const auto & tf_info = get_tf_info();
+  odom_msg.header.frame_id = tf_info.map_frame;
+  odom_msg.child_frame_id = tf_info.robot_frame;
 
   tf2::Transform est_pose = getEstimatedPose();
 

--- a/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
@@ -386,7 +386,7 @@ void AMCLLocalizer::correct(NavState & nav_state)
 
   const auto & map_static = nav_state.get<SimpleMap>("map.static");
 
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   const auto & filtered = PointPerceptionsOpsView(perceptions)
     .downsample(map_static.resolution())
     .fuse(tf_info.robot_frame)
@@ -527,7 +527,7 @@ AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
 {
   geometry_msgs::msg::TransformStamped tf_msg;
   tf_msg.header.stamp = get_node()->now();
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   tf_msg.header.frame_id = tf_info.map_frame;
   tf_msg.child_frame_id = tf_info.odom_frame;
   tf_msg.transform = tf2::toMsg(map2bf);
@@ -539,9 +539,11 @@ AMCLLocalizer::publishTF(const tf2::Transform & map2bf)
 void
 AMCLLocalizer::publishParticles()
 {
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   geometry_msgs::msg::PoseArray array_msg;
   array_msg.header.stamp = get_node()->now();
-  array_msg.header.frame_id = get_tf_info().map_frame;
+  array_msg.header.frame_id = tf_info.map_frame;
 
   array_msg.poses.reserve(particles_.size());
   for (const auto & p : particles_) {
@@ -600,9 +602,11 @@ AMCLLocalizer::publishEstimatedPose(const tf2::Transform & est_pose)
   tf2::Matrix3x3 cov = computeCovariance(particles_, 0, N_top, mean);
   double yaw_variance = computeYawVariance(particles_, 0, N_top);
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   geometry_msgs::msg::PoseWithCovarianceStamped msg;
   msg.header.stamp = get_node()->now();
-  msg.header.frame_id = get_tf_info().map_frame;
+  msg.header.frame_id = tf_info.map_frame;
 
   msg.pose.pose.position.x = mean.x();
   msg.pose.pose.position.y = mean.y();
@@ -625,7 +629,7 @@ AMCLLocalizer::get_pose()
   nav_msgs::msg::Odometry odom_msg;
 
   odom_msg.header.stamp = get_node()->now();
-  const auto & tf_info = get_tf_info();
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
   odom_msg.header.frame_id = tf_info.map_frame;
   odom_msg.child_frame_id = tf_info.robot_frame;
 

--- a/localizers/easynav_simple_localizer/tests/simple_localizer_tests.cpp
+++ b/localizers/easynav_simple_localizer/tests/simple_localizer_tests.cpp
@@ -104,7 +104,11 @@ TEST_F(AMCLLocalizerTest, IncomingOccupancyGridUpdatesMaps)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_node2");
   auto manager = std::make_shared<easynav::AMCLLocalizer>();
-  manager->initialize(node, "test2");
+  easynav::TFInfo tf_info;
+  tf_info.map_frame = "world_map";
+  tf_info.odom_frame = "world_odom";
+  tf_info.robot_frame = "world_base";
+  manager->initialize(node, "test2", tf_info);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node->get_node_base_interface());
@@ -114,7 +118,7 @@ TEST_F(AMCLLocalizerTest, IncomingOccupancyGridUpdatesMaps)
     "test_node2/test2/incoming_map", rclcpp::QoS(1).transient_local().reliable());
 
   nav_msgs::msg::OccupancyGrid grid;
-  grid.header.frame_id = "map";
+  grid.header.frame_id = tf_info.map_frame;
   grid.info.width = 10;
   grid.info.height = 10;
   grid.info.resolution = 0.2;

--- a/localizers/easynav_simple_localizer/tests/simple_localizer_tests.cpp
+++ b/localizers/easynav_simple_localizer/tests/simple_localizer_tests.cpp
@@ -108,7 +108,9 @@ TEST_F(AMCLLocalizerTest, IncomingOccupancyGridUpdatesMaps)
   tf_info.map_frame = "world_map";
   tf_info.odom_frame = "world_odom";
   tf_info.robot_frame = "world_base";
-  manager->initialize(node, "test2", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  manager->initialize(node, "test2");
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node->get_node_base_interface());

--- a/maps_managers/easynav_bonxai_maps_manager/include/easynav_bonxai_maps_manager/BonxaiMapsManager.hpp
+++ b/maps_managers/easynav_bonxai_maps_manager/include/easynav_bonxai_maps_manager/BonxaiMapsManager.hpp
@@ -118,7 +118,6 @@ private:
 
   double resolution_ {0.3};
   double height_with_occ_ {1.0};
-  std::string frame_id_ {"map"};
 };
 
 }  // namespace easynav_bonxai

--- a/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
+++ b/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
@@ -64,13 +64,11 @@ BonxaiMapsManager::on_initialize()
   node->declare_parameter(plugin_name + ".bonxai_path_file", bonxai_path_file);
   node->declare_parameter(plugin_name + ".occmap_path_file", occmap_path_file);
   node->declare_parameter(plugin_name + ".resolution", resolution_);
-  node->declare_parameter(plugin_name + ".frame_id", frame_id_);
 
   node->get_parameter(plugin_name + ".package", package_name);
   node->get_parameter(plugin_name + ".bonxai_path_file", bonxai_path_file);
   node->get_parameter(plugin_name + ".occmap_path_file", occmap_path_file);
   node->get_parameter(plugin_name + ".resolution", resolution_);
-  node->get_parameter(plugin_name + ".frame_id", frame_id_);
 
   bonxai_pub_ = node->create_publisher<sensor_msgs::msg::PointCloud2>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/map",
@@ -181,7 +179,8 @@ BonxaiMapsManager::update_from_pc2(const sensor_msgs::msg::PointCloud2 & pc2)
   geometry_msgs::msg::TransformStamped tf_msg;
   try {
     tf_msg = ::easynav::RTTFBuffer::getInstance()->lookupTransform(
-          frame_id_, pc2.header.frame_id, pc2.header.stamp, rclcpp::Duration::from_seconds(0.05));
+          get_tf_info().map_frame, pc2.header.frame_id, pc2.header.stamp,
+          rclcpp::Duration::from_seconds(0.05));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN(get_node()->get_logger(), "OctomapMapsManager: TF failed: %s", ex.what());
     return;
@@ -285,7 +284,7 @@ BonxaiMapsManager::update_from_occ(const nav_msgs::msg::OccupancyGrid & occ)
 void
 BonxaiMapsManager::publish_map()
 {
-  bonxai_msg_.header.frame_id = frame_id_;
+  bonxai_msg_.header.frame_id = get_tf_info().map_frame;
   bonxai_msg_.header.stamp = this->get_node()->now();
   bonxai_pub_->publish(bonxai_msg_);
 

--- a/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
+++ b/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
@@ -175,11 +175,12 @@ BonxaiMapsManager::update(::easynav::NavState & nav_state)
 void
 BonxaiMapsManager::update_from_pc2(const sensor_msgs::msg::PointCloud2 & pc2)
 {
+  const auto & tf_info = ::easynav::RTTFBuffer::getInstance()->get_tf_info();
 
   geometry_msgs::msg::TransformStamped tf_msg;
   try {
     tf_msg = ::easynav::RTTFBuffer::getInstance()->lookupTransform(
-          get_tf_info().map_frame, pc2.header.frame_id, pc2.header.stamp,
+          tf_info.map_frame, pc2.header.frame_id, pc2.header.stamp,
           rclcpp::Duration::from_seconds(0.05));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN(get_node()->get_logger(), "OctomapMapsManager: TF failed: %s", ex.what());
@@ -284,7 +285,9 @@ BonxaiMapsManager::update_from_occ(const nav_msgs::msg::OccupancyGrid & occ)
 void
 BonxaiMapsManager::publish_map()
 {
-  bonxai_msg_.header.frame_id = get_tf_info().map_frame;
+  const auto & tf_info = ::easynav::RTTFBuffer::getInstance()->get_tf_info();
+
+  bonxai_msg_.header.frame_id = tf_info.map_frame;
   bonxai_msg_.header.stamp = this->get_node()->now();
   bonxai_pub_->publish(bonxai_msg_);
 

--- a/maps_managers/easynav_costmap_maps_manager/include/easynav_costmap_maps_manager/filters/CostmapFilter.hpp
+++ b/maps_managers/easynav_costmap_maps_manager/include/easynav_costmap_maps_manager/filters/CostmapFilter.hpp
@@ -25,7 +25,6 @@
 #include <string>
 
 #include "easynav_common/types/NavState.hpp"
-#include "easynav_common/types/TFInfo.hpp"
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -46,8 +45,7 @@ public:
   std::expected<void, std::string>
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-    const std::string & plugin_name,
-    const TFInfo & tf_info);
+    const std::string & plugin_name);
 
   virtual std::expected<void, std::string> on_initialize() = 0;
   virtual void update(NavState & nav_state) = 0;
@@ -57,13 +55,9 @@ public:
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node() const;
 
-
-  const TFInfo & get_tf_info() const;
-
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_ {nullptr};
   std::string plugin_name_;
-  TFInfo tf_info_;
 };
 }  // namespace easynav
 

--- a/maps_managers/easynav_costmap_maps_manager/include/easynav_costmap_maps_manager/filters/CostmapFilter.hpp
+++ b/maps_managers/easynav_costmap_maps_manager/include/easynav_costmap_maps_manager/filters/CostmapFilter.hpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "easynav_common/types/NavState.hpp"
+#include "easynav_common/types/TFInfo.hpp"
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -46,7 +47,7 @@ public:
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
     const std::string & plugin_name,
-    const std::string & tf_prefix = "");
+    const TFInfo & tf_info);
 
   virtual std::expected<void, std::string> on_initialize() = 0;
   virtual void update(NavState & nav_state) = 0;
@@ -57,12 +58,12 @@ protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node() const;
 
 
-  const std::string & get_tf_prefix() const;
+  const TFInfo & get_tf_info() const;
 
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_ {nullptr};
   std::string plugin_name_;
-  std::string tf_prefix_;
+  TFInfo tf_info_;
 };
 }  // namespace easynav
 

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
@@ -26,6 +26,7 @@
 
 #include "easynav_costmap_common/costmap_2d.hpp"
 #include "easynav_costmap_maps_manager/map_io.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
@@ -80,8 +81,7 @@ CostmapMapsManager::on_initialize()
       std::shared_ptr<CostmapFilter> instance;
       instance = costmap_filters_loader_->createSharedInstance(plugin);
 
-      auto result = instance->initialize(node, plugin_name + "." + costmap_filter,
-        get_tf_info());
+      auto result = instance->initialize(node, plugin_name + "." + costmap_filter);
 
       if (!result) {
         RCLCPP_ERROR(node->get_logger(),
@@ -109,6 +109,8 @@ CostmapMapsManager::on_initialize()
   dynamic_occ_pub_ = node->create_publisher<nav_msgs::msg::OccupancyGrid>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/dynamic_map", 100);
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   map_path_ = "/tmp/default.map.yaml";
   if (!package_name.empty() && !map_path_file.empty()) {
     try {
@@ -125,7 +127,7 @@ CostmapMapsManager::on_initialize()
 
     static_map_ = Costmap2D(static_grid_msg_);
 
-    static_grid_msg_.header.frame_id = get_tf_info().map_frame;
+    static_grid_msg_.header.frame_id = tf_info.map_frame;
     static_grid_msg_.header.stamp = node->now();
     static_occ_pub_->publish(static_grid_msg_);
   }
@@ -133,12 +135,12 @@ CostmapMapsManager::on_initialize()
   incoming_map_sub_ = node->create_subscription<nav_msgs::msg::OccupancyGrid>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/incoming_map",
     rclcpp::QoS(1).transient_local().reliable(),
-    [this](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
+    [&](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
       static_grid_msg_ = *msg;
 
       static_map_ = Costmap2D(*msg);
 
-      static_grid_msg_.header.frame_id = get_tf_info().map_frame;
+      static_grid_msg_.header.frame_id = tf_info.map_frame;
       static_grid_msg_.header.stamp = this->get_node()->now();
 
       static_occ_pub_->publish(static_grid_msg_);
@@ -146,7 +148,7 @@ CostmapMapsManager::on_initialize()
 
   savemap_srv_ = node->create_service<std_srvs::srv::Trigger>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/savemap",
-    [this](
+    [&](
       const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
       std::shared_ptr<std_srvs::srv::Trigger::Response> response)
     {
@@ -201,8 +203,10 @@ CostmapMapsManager::update(NavState & nav_state)
 
   nav_state.set("map.dynamic", dynamic_map_);
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   dynamic_map_->toOccupancyGridMsg(dynamic_grid_msg_);
-  dynamic_grid_msg_.header.frame_id = get_tf_info().map_frame;
+  dynamic_grid_msg_.header.frame_id = tf_info.map_frame;
   dynamic_grid_msg_.header.stamp = get_node()->now();
   dynamic_occ_pub_->publish(dynamic_grid_msg_);
 }

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
@@ -81,7 +81,7 @@ CostmapMapsManager::on_initialize()
       instance = costmap_filters_loader_->createSharedInstance(plugin);
 
       auto result = instance->initialize(node, plugin_name + "." + costmap_filter,
-        get_tf_prefix());
+        get_tf_info());
 
       if (!result) {
         RCLCPP_ERROR(node->get_logger(),
@@ -125,7 +125,7 @@ CostmapMapsManager::on_initialize()
 
     static_map_ = Costmap2D(static_grid_msg_);
 
-    static_grid_msg_.header.frame_id = get_tf_prefix() + "map";
+    static_grid_msg_.header.frame_id = get_tf_info().map_frame;
     static_grid_msg_.header.stamp = node->now();
     static_occ_pub_->publish(static_grid_msg_);
   }
@@ -138,7 +138,7 @@ CostmapMapsManager::on_initialize()
 
       static_map_ = Costmap2D(*msg);
 
-      static_grid_msg_.header.frame_id = get_tf_prefix() + "map";
+      static_grid_msg_.header.frame_id = get_tf_info().map_frame;
       static_grid_msg_.header.stamp = this->get_node()->now();
 
       static_occ_pub_->publish(static_grid_msg_);
@@ -202,7 +202,7 @@ CostmapMapsManager::update(NavState & nav_state)
   nav_state.set("map.dynamic", dynamic_map_);
 
   dynamic_map_->toOccupancyGridMsg(dynamic_grid_msg_);
-  dynamic_grid_msg_.header.frame_id = get_tf_prefix() + "map";
+  dynamic_grid_msg_.header.frame_id = get_tf_info().map_frame;
   dynamic_grid_msg_.header.stamp = get_node()->now();
   dynamic_occ_pub_->publish(dynamic_grid_msg_);
 }

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/CostmapFilter.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/CostmapFilter.cpp
@@ -35,12 +35,11 @@ std::expected<void, std::string>
 CostmapFilter::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
   const std::string & plugin_name,
-  const std::string & tf_prefix
-)
+  const TFInfo & tf_info)
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
-  tf_prefix_ = tf_prefix;
+  tf_info_ = tf_info;
 
   return on_initialize();
 }
@@ -57,10 +56,10 @@ CostmapFilter::get_plugin_name() const
   return plugin_name_;
 }
 
-const std::string &
-CostmapFilter::get_tf_prefix() const
+const TFInfo &
+CostmapFilter::get_tf_info() const
 {
-  return tf_prefix_;
+  return tf_info_;
 }
 
 }  // namespace easynav

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/CostmapFilter.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/CostmapFilter.cpp
@@ -34,12 +34,10 @@ CostmapFilter::CostmapFilter()
 std::expected<void, std::string>
 CostmapFilter::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-  const std::string & plugin_name,
-  const TFInfo & tf_info)
+  const std::string & plugin_name)
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
-  tf_info_ = tf_info;
 
   return on_initialize();
 }
@@ -56,10 +54,5 @@ CostmapFilter::get_plugin_name() const
   return plugin_name_;
 }
 
-const TFInfo &
-CostmapFilter::get_tf_info() const
-{
-  return tf_info_;
-}
 
 }  // namespace easynav

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/ObstacleFilter.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/ObstacleFilter.cpp
@@ -56,10 +56,11 @@ ObstacleFilter::update(NavState & nav_state)
 
   auto dynamic_map_ptr = nav_state.get_ptr<Costmap2D>("map.dynamic.filtered");
   Costmap2D & dynamic_map = *dynamic_map_ptr;
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(dynamic_map.getResolution())
-    .fuse(get_tf_info().map_frame)
+    .fuse(tf_info.map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .as_points();
 

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/ObstacleFilter.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/ObstacleFilter.cpp
@@ -59,7 +59,7 @@ ObstacleFilter::update(NavState & nav_state)
 
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(dynamic_map.getResolution())
-    .fuse(get_tf_prefix() + "map")
+    .fuse(get_tf_info().map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .as_points();
 

--- a/maps_managers/easynav_navmap_maps_manager/include/easynav_navmap_maps_manager/filters/NavMapFilter.hpp
+++ b/maps_managers/easynav_navmap_maps_manager/include/easynav_navmap_maps_manager/filters/NavMapFilter.hpp
@@ -25,7 +25,6 @@
 #include <string>
 
 #include "easynav_common/types/NavState.hpp"
-#include "easynav_common/types/TFInfo.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace easynav
@@ -41,8 +40,7 @@ public:
   std::expected<void, std::string>
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-    const std::string & plugin_name,
-    const TFInfo & tf_info);
+    const std::string & plugin_name);
 
   virtual std::expected<void, std::string> on_initialize() = 0;
   virtual void update(::easynav::NavState & nav_state) = 0;
@@ -55,15 +53,12 @@ public:
 
   const std::string & get_plugin_name() const;
 
-  const TFInfo & get_tf_info() const;
-
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node() const;
 
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_ {nullptr};
   std::string plugin_name_;
-  TFInfo tf_info_;
 
   float map_resolution_ {0.1};
 };

--- a/maps_managers/easynav_navmap_maps_manager/include/easynav_navmap_maps_manager/filters/NavMapFilter.hpp
+++ b/maps_managers/easynav_navmap_maps_manager/include/easynav_navmap_maps_manager/filters/NavMapFilter.hpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "easynav_common/types/NavState.hpp"
+#include "easynav_common/types/TFInfo.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace easynav
@@ -41,7 +42,7 @@ public:
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
     const std::string & plugin_name,
-    const std::string & tf_prefix = "");
+    const TFInfo & tf_info);
 
   virtual std::expected<void, std::string> on_initialize() = 0;
   virtual void update(::easynav::NavState & nav_state) = 0;
@@ -54,14 +55,15 @@ public:
 
   const std::string & get_plugin_name() const;
 
+  const TFInfo & get_tf_info() const;
+
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node() const;
-  const std::string & get_tf_prefix() const;
 
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_ {nullptr};
   std::string plugin_name_;
-  std::string tf_prefix_;
+  TFInfo tf_info_;
 
   float map_resolution_ {0.1};
 };

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
@@ -93,7 +93,7 @@ NavMapMapsManager::on_initialize()
       instance = navmap_filters_loader_->createSharedInstance(plugin);
 
       auto result = instance->initialize(node, plugin_name + "." + navmap_filter,
-        get_tf_prefix());
+        get_tf_info());
 
       if (!result) {
         RCLCPP_ERROR(node->get_logger(),

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
@@ -23,6 +23,7 @@
 #include "easynav_navmap_maps_manager/NavMapMapsManager.hpp"
 
 #include "easynav_common/YTSession.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "navmap_core/NavMap.hpp"
 #include "navmap_ros/conversions.hpp"
@@ -92,8 +93,7 @@ NavMapMapsManager::on_initialize()
       std::shared_ptr<NavMapFilter> instance;
       instance = navmap_filters_loader_->createSharedInstance(plugin);
 
-      auto result = instance->initialize(node, plugin_name + "." + navmap_filter,
-        get_tf_info());
+      auto result = instance->initialize(node, plugin_name + "." + navmap_filter);
 
       if (!result) {
         RCLCPP_ERROR(node->get_logger(),
@@ -122,6 +122,9 @@ NavMapMapsManager::on_initialize()
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/map_updates",
     rclcpp::QoS(100));
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
+
   if (!package_name.empty() && !occmap_path_file.empty()) {
     try {
       const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
@@ -140,7 +143,7 @@ NavMapMapsManager::on_initialize()
     navmap_ = navmap_ros::from_occupancy_grid(occ_msg);
 
     navmap_msg_ = navmap_ros::to_msg(navmap_);
-    navmap_msg_.header.frame_id = get_tf_info().map_frame;
+    navmap_msg_.header.frame_id = tf_info.map_frame;
     navmap_msg_.header.stamp = node->now();
     navmap_pub_->publish(navmap_msg_);
   }
@@ -155,7 +158,7 @@ NavMapMapsManager::on_initialize()
 
     if (navmap_ros::io::load_from_file(map_path_, navmap_)) {
       navmap_msg_ = navmap_ros::to_msg(navmap_);
-      navmap_msg_.header.frame_id = get_tf_info().map_frame;
+      navmap_msg_.header.frame_id = tf_info.map_frame;
       navmap_msg_.header.stamp = node->now();
       navmap_pub_->publish(navmap_msg_);
     } else {
@@ -166,13 +169,13 @@ NavMapMapsManager::on_initialize()
   incoming_occ_map_sub_ = node->create_subscription<nav_msgs::msg::OccupancyGrid>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/incoming_occ_map",
     rclcpp::QoS(1).transient_local().reliable(),
-    [this](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
+    [&](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
 
       resolution_ = msg->info.resolution;
       navmap_ = navmap_ros::from_occupancy_grid(*msg);
 
       navmap_msg_ = navmap_ros::to_msg(navmap_);
-      navmap_msg_.header.frame_id = get_tf_info().map_frame;
+      navmap_msg_.header.frame_id = tf_info.map_frame;
       navmap_msg_.header.stamp = this->get_node()->now();
       navmap_pub_->publish(navmap_msg_);
     });
@@ -180,13 +183,13 @@ NavMapMapsManager::on_initialize()
   incoming_pc2_map_sub_ = node->create_subscription<sensor_msgs::msg::PointCloud2>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/incoming_pc2_map",
     rclcpp::QoS(100),
-    [this](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
+    [&](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
 
       navmap_ros::BuildParams params;
       navmap_ = navmap_ros::from_pointcloud2(*msg, navmap_msg_, params);
 
 
-      navmap_msg_.header.frame_id = get_tf_info().map_frame;
+      navmap_msg_.header.frame_id = tf_info.map_frame;
       navmap_msg_.header.stamp = this->get_node()->now();
       navmap_pub_->publish(navmap_msg_);
     });

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
@@ -140,7 +140,7 @@ NavMapMapsManager::on_initialize()
     navmap_ = navmap_ros::from_occupancy_grid(occ_msg);
 
     navmap_msg_ = navmap_ros::to_msg(navmap_);
-    navmap_msg_.header.frame_id = "map";
+    navmap_msg_.header.frame_id = get_tf_info().map_frame;
     navmap_msg_.header.stamp = node->now();
     navmap_pub_->publish(navmap_msg_);
   }
@@ -155,7 +155,7 @@ NavMapMapsManager::on_initialize()
 
     if (navmap_ros::io::load_from_file(map_path_, navmap_)) {
       navmap_msg_ = navmap_ros::to_msg(navmap_);
-      navmap_msg_.header.frame_id = "map";
+      navmap_msg_.header.frame_id = get_tf_info().map_frame;
       navmap_msg_.header.stamp = node->now();
       navmap_pub_->publish(navmap_msg_);
     } else {
@@ -172,7 +172,7 @@ NavMapMapsManager::on_initialize()
       navmap_ = navmap_ros::from_occupancy_grid(*msg);
 
       navmap_msg_ = navmap_ros::to_msg(navmap_);
-      navmap_msg_.header.frame_id = "map";
+      navmap_msg_.header.frame_id = get_tf_info().map_frame;
       navmap_msg_.header.stamp = this->get_node()->now();
       navmap_pub_->publish(navmap_msg_);
     });
@@ -186,7 +186,7 @@ NavMapMapsManager::on_initialize()
       navmap_ = navmap_ros::from_pointcloud2(*msg, navmap_msg_, params);
 
 
-      navmap_msg_.header.frame_id = "map";
+      navmap_msg_.header.frame_id = get_tf_info().map_frame;
       navmap_msg_.header.stamp = this->get_node()->now();
       navmap_pub_->publish(navmap_msg_);
     });

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/NavMapFilter.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/NavMapFilter.cpp
@@ -37,12 +37,11 @@ std::expected<void, std::string>
 NavMapFilter::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
   const std::string & plugin_name,
-  const std::string & tf_prefix
-)
+  const TFInfo & tf_info)
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
-  tf_prefix_ = tf_prefix;
+  tf_info_ = tf_info;
 
   return on_initialize();
 }
@@ -59,10 +58,10 @@ NavMapFilter::get_plugin_name() const
   return plugin_name_;
 }
 
-const std::string &
-NavMapFilter::get_tf_prefix() const
+const TFInfo &
+NavMapFilter::get_tf_info() const
 {
-  return tf_prefix_;
+  return tf_info_;
 }
 
 }  // namespace navmap

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/NavMapFilter.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/NavMapFilter.cpp
@@ -36,12 +36,10 @@ NavMapFilter::NavMapFilter()
 std::expected<void, std::string>
 NavMapFilter::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-  const std::string & plugin_name,
-  const TFInfo & tf_info)
+  const std::string & plugin_name)
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
-  tf_info_ = tf_info;
 
   return on_initialize();
 }
@@ -56,12 +54,6 @@ const std::string &
 NavMapFilter::get_plugin_name() const
 {
   return plugin_name_;
-}
-
-const TFInfo &
-NavMapFilter::get_tf_info() const
-{
-  return tf_info_;
 }
 
 }  // namespace navmap

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/ObstacleFilter.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/ObstacleFilter.cpp
@@ -60,7 +60,7 @@ void ObstacleFilter::update(::easynav::NavState & nav_state)
   const auto & points = PointPerceptionsOpsView(perceptions)
     .filter({-10.0, -10.0, NAN}, {10.0, 10.0, NAN})
     .downsample(0.3)
-    .fuse("map")
+    .fuse(get_tf_info().map_frame)
     .as_points();
 
   const float voxel_xy = 0.30f;

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/ObstacleFilter.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/filters/ObstacleFilter.cpp
@@ -24,6 +24,7 @@
 
 #include "easynav_common/types/NavState.hpp"
 #include "easynav_common/types/PointPerception.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "navmap_core/NavMap.hpp"
 #include "navmap_ros/conversions.hpp"
@@ -54,13 +55,14 @@ void ObstacleFilter::update(::easynav::NavState & nav_state)
 
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
   navmap_ = nav_state.get<::navmap::NavMap>("map.navmap");
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
   navmap_.layer_clear<uint8_t>(get_layer_name(), navmap_ros::FREE_SPACE);
 
   const auto & points = PointPerceptionsOpsView(perceptions)
     .filter({-10.0, -10.0, NAN}, {10.0, 10.0, NAN})
     .downsample(0.3)
-    .fuse(get_tf_info().map_frame)
+    .fuse(tf_info.map_frame)
     .as_points();
 
   const float voxel_xy = 0.30f;

--- a/maps_managers/easynav_octomap_maps_manager/include/easynav_octomap_maps_manager/filters/OctomapFilter.hpp
+++ b/maps_managers/easynav_octomap_maps_manager/include/easynav_octomap_maps_manager/filters/OctomapFilter.hpp
@@ -26,7 +26,6 @@
 
 #include "octomap/octomap.h"
 #include "easynav_common/types/NavState.hpp"
-#include "easynav_common/types/TFInfo.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace easynav
@@ -42,8 +41,7 @@ public:
   std::expected<void, std::string>
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-    const std::string & plugin_name,
-    const TFInfo & tf_info);
+    const std::string & plugin_name);
 
   virtual std::expected<void, std::string> on_initialize() = 0;
   virtual void update(::easynav::NavState & nav_state) = 0;
@@ -56,12 +54,9 @@ protected:
 
   const std::string & get_plugin_name() const;
 
-  const TFInfo & get_tf_info() const;
-
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_ {nullptr};
   std::string plugin_name_;
-  TFInfo tf_info_;
 
   float map_resolution_ {0.1};
 };

--- a/maps_managers/easynav_octomap_maps_manager/include/easynav_octomap_maps_manager/filters/OctomapFilter.hpp
+++ b/maps_managers/easynav_octomap_maps_manager/include/easynav_octomap_maps_manager/filters/OctomapFilter.hpp
@@ -26,6 +26,7 @@
 
 #include "octomap/octomap.h"
 #include "easynav_common/types/NavState.hpp"
+#include "easynav_common/types/TFInfo.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace easynav
@@ -42,7 +43,7 @@ public:
   initialize(
     const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
     const std::string & plugin_name,
-    const std::string & tf_prefix = "");
+    const TFInfo & tf_info);
 
   virtual std::expected<void, std::string> on_initialize() = 0;
   virtual void update(::easynav::NavState & nav_state) = 0;
@@ -55,12 +56,12 @@ protected:
 
   const std::string & get_plugin_name() const;
 
-  const std::string & get_tf_prefix() const;
+  const TFInfo & get_tf_info() const;
 
 protected:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node_ {nullptr};
   std::string plugin_name_;
-  std::string tf_prefix_;
+  TFInfo tf_info_;
 
   float map_resolution_ {0.1};
 };

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
@@ -179,7 +179,8 @@ OctomapMapsManager::on_initialize()
       geometry_msgs::msg::TransformStamped tf_msg;
       try {
         tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-          "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration::from_seconds(0.05));
+          get_tf_info().map_frame, msg->header.frame_id, msg->header.stamp,
+            rclcpp::Duration::from_seconds(0.05));
       } catch (const tf2::TransformException & ex) {
         RCLCPP_WARN(get_node()->get_logger(), "OctomapMapsManager: TF failed: %s", ex.what());
         return;
@@ -223,7 +224,7 @@ OctomapMapsManager::on_initialize()
       octomap_->updateInnerOccupancy();
 
 
-      octomap_msg_.header.frame_id = "map";
+      octomap_msg_.header.frame_id = get_tf_info().map_frame;
       octomap_msg_.header.stamp = this->get_node()->now();
       octomap_msg_.id = "OcTree";
       octomap_msg_.binary = true;

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
@@ -171,15 +171,17 @@ OctomapMapsManager::on_initialize()
 //      octomap_pub_->publish(octomap_msg_);
 //    });
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   incoming_pc2_map_sub_ = node->create_subscription<sensor_msgs::msg::PointCloud2>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/incoming_pc2_map",
     rclcpp::QoS(100),
-    [this](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
+    [&](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
 
       geometry_msgs::msg::TransformStamped tf_msg;
       try {
         tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-          get_tf_info().map_frame, msg->header.frame_id, msg->header.stamp,
+          tf_info.map_frame, msg->header.frame_id, msg->header.stamp,
             rclcpp::Duration::from_seconds(0.05));
       } catch (const tf2::TransformException & ex) {
         RCLCPP_WARN(get_node()->get_logger(), "OctomapMapsManager: TF failed: %s", ex.what());
@@ -223,8 +225,7 @@ OctomapMapsManager::on_initialize()
       octomap_->insertPointCloud(cloud, origin, 1000.0, true, false);
       octomap_->updateInnerOccupancy();
 
-
-      octomap_msg_.header.frame_id = get_tf_info().map_frame;
+      octomap_msg_.header.frame_id = tf_info.map_frame;
       octomap_msg_.header.stamp = this->get_node()->now();
       octomap_msg_.id = "OcTree";
       octomap_msg_.binary = true;

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/ObstacleFilter.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/ObstacleFilter.cpp
@@ -58,6 +58,7 @@ ObstacleFilter::update(::easynav::NavState & nav_state)
 
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
   octomap_ = nav_state.get<::octomap::Octomap>("map");
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
   if (!octomap_.layer_copy<uint8_t>("occupancy", "obstacles")) {
     RCLCPP_ERROR(parent_node_->get_logger(), "Error copying layers at ObstacleFilter");
@@ -66,7 +67,7 @@ ObstacleFilter::update(::easynav::NavState & nav_state)
 
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(get_map_resolution())
-    .fuse(get_tf_info().map_frame)
+    .fuse(tf_info.map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .as_points();
 

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/ObstacleFilter.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/ObstacleFilter.cpp
@@ -66,7 +66,7 @@ ObstacleFilter::update(::easynav::NavState & nav_state)
 
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(get_map_resolution())
-    .fuse(get_tf_prefix() + "map")
+    .fuse(get_tf_info().map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .as_points();
 

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/OctomapFilter.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/OctomapFilter.cpp
@@ -39,12 +39,12 @@ std::expected<void, std::string>
 OctomapFilter::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
   const std::string & plugin_name,
-  const std::string & tf_prefix
+  const TFInfo & tf_info
 )
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
-  tf_prefix_ = tf_prefix;
+  tf_info_ = tf_info;
 
   return on_initialize();
 }
@@ -61,10 +61,10 @@ OctomapFilter::get_plugin_name() const
   return plugin_name_;
 }
 
-const std::string &
-OctomapFilter::get_tf_prefix() const
+const TFInfo &
+OctomapFilter::get_tf_info() const
 {
-  return tf_prefix_;
+  return tf_info_;
 }
 
 }  // namespace octomap

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/OctomapFilter.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/filters/OctomapFilter.cpp
@@ -38,14 +38,10 @@ OctomapFilter::OctomapFilter()
 std::expected<void, std::string>
 OctomapFilter::initialize(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> parent_node,
-  const std::string & plugin_name,
-  const TFInfo & tf_info
-)
+  const std::string & plugin_name)
 {
   parent_node_ = parent_node;
   plugin_name_ = plugin_name;
-  tf_info_ = tf_info;
-
   return on_initialize();
 }
 
@@ -59,12 +55,6 @@ const std::string &
 OctomapFilter::get_plugin_name() const
 {
   return plugin_name_;
-}
-
-const TFInfo &
-OctomapFilter::get_tf_info() const
-{
-  return tf_info_;
 }
 
 }  // namespace octomap

--- a/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/RoutesFilter.hpp
+++ b/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/RoutesFilter.hpp
@@ -26,7 +26,6 @@
 #include <vector>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
-#include "easynav_common/types/TFInfo.hpp"
 
 namespace easynav
 {
@@ -63,8 +62,7 @@ public:
   ///   an error message describing the failure.
   virtual std::expected<void, std::string> initialize(
     const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
-    const std::string & plugin_ns,
-    const TFInfo & tf_info) = 0;
+    const std::string & plugin_ns) = 0;
 
   /// @brief Update hook called every navigation cycle.
   ///

--- a/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/RoutesFilter.hpp
+++ b/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/RoutesFilter.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "easynav_common/types/TFInfo.hpp"
 
 namespace easynav
 {
@@ -57,13 +58,13 @@ public:
   /// @param node Shared pointer to the owning lifecycle node.
   /// @param plugin_ns Namespace under which this filter is configured
   ///   (used as prefix for ROS parameters and topics).
-  /// @param tf_prefix TF frame prefix used by the navigation stack.
+  /// @param tf_info TF frame information used by the navigation stack.
   /// @return std::expected<void, std::string> Empty on success or
   ///   an error message describing the failure.
   virtual std::expected<void, std::string> initialize(
     const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
     const std::string & plugin_ns,
-    const std::string & tf_prefix) = 0;
+    const TFInfo & tf_info) = 0;
 
   /// @brief Update hook called every navigation cycle.
   ///

--- a/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/filters/RoutesCostmapFilter.hpp
+++ b/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/filters/RoutesCostmapFilter.hpp
@@ -58,8 +58,7 @@ public:
   ///   error message on failure.
   std::expected<void, std::string> initialize(
     const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
-    const std::string & plugin_ns,
-    const TFInfo & tf_info) override;
+    const std::string & plugin_ns) override;
 
   /// @brief Apply the routes-based filtering to the costmap.
   ///
@@ -78,9 +77,6 @@ private:
 
   /// @brief Plugin namespace used for parameters and topics.
   std::string plugin_ns_;
-
-  /// @brief TF info used in the navigation stack.
-  TFInfo tf_info_;
 
   /// @brief Minimum cost enforced outside the route corridor.
   int min_cost_{50};

--- a/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/filters/RoutesCostmapFilter.hpp
+++ b/maps_managers/easynav_routes_maps_manager/include/easynav_routes_maps_manager/filters/RoutesCostmapFilter.hpp
@@ -53,14 +53,13 @@ public:
   ///   RoutesMapsManager.
   /// @param plugin_ns Namespace used to resolve this filter's
   ///   parameters and topics.
-  /// @param tf_prefix TF frame prefix; used to set the frame id of
-  ///   the published debug grid.
+  /// @param tf_info TF frame information used by the navigation stack.
   /// @return std::expected<void, std::string> Empty on success or an
   ///   error message on failure.
   std::expected<void, std::string> initialize(
     const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
     const std::string & plugin_ns,
-    const std::string & tf_prefix) override;
+    const TFInfo & tf_info) override;
 
   /// @brief Apply the routes-based filtering to the costmap.
   ///
@@ -80,8 +79,8 @@ private:
   /// @brief Plugin namespace used for parameters and topics.
   std::string plugin_ns_;
 
-  /// @brief TF prefix used for published frame ids.
-  std::string tf_prefix_;
+  /// @brief TF info used in the navigation stack.
+  TFInfo tf_info_;
 
   /// @brief Minimum cost enforced outside the route corridor.
   int min_cost_{50};

--- a/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
+++ b/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
@@ -392,7 +392,7 @@ void RoutesMapsManager::publish_routes_markers()
    // removed segments do not leave orphaned markers behind.
   {
     visualization_msgs::msg::Marker m;
-    m.header.frame_id = "map";
+    m.header.frame_id = get_tf_info().map_frame;
     m.action = visualization_msgs::msg::Marker::DELETEALL;
 
     m.ns = "routes_line";
@@ -406,7 +406,7 @@ void RoutesMapsManager::publish_routes_markers()
   for (const auto & seg : routes_) {
     // Line between start and end
     visualization_msgs::msg::Marker line;
-    line.header.frame_id = "map";
+    line.header.frame_id = get_tf_info().map_frame;
     line.ns = "routes_line";
     line.id = id++;
     line.type = visualization_msgs::msg::Marker::LINE_LIST;
@@ -432,7 +432,7 @@ void RoutesMapsManager::publish_routes_markers()
 
     // Arrow for start orientation (same style as end)
     visualization_msgs::msg::Marker start_arrow;
-    start_arrow.header.frame_id = "map";
+    start_arrow.header.frame_id = get_tf_info().map_frame;
     start_arrow.ns = "routes_arrow";
     start_arrow.id = id++;
     start_arrow.type = visualization_msgs::msg::Marker::ARROW;
@@ -449,7 +449,7 @@ void RoutesMapsManager::publish_routes_markers()
 
     // Arrow for end orientation (same style)
     visualization_msgs::msg::Marker end_arrow;
-    end_arrow.header.frame_id = "map";
+    end_arrow.header.frame_id = get_tf_info().map_frame;
     end_arrow.ns = "routes_arrow";
     end_arrow.id = id++;
     end_arrow.type = visualization_msgs::msg::Marker::ARROW;
@@ -478,7 +478,7 @@ void RoutesMapsManager::publish_interactive_markers()
   for (const auto & seg : routes_) {
     // Per-segment toggle cube (red in normal mode, green in edit mode).
     visualization_msgs::msg::InteractiveMarker mode_marker;
-    mode_marker.header.frame_id = "map";
+    mode_marker.header.frame_id = get_tf_info().map_frame;
     mode_marker.name = seg.id + "_mode";
     mode_marker.scale = 1.0;
 
@@ -540,14 +540,14 @@ void RoutesMapsManager::publish_interactive_markers()
     }
 
     visualization_msgs::msg::InteractiveMarker start_marker;
-    start_marker.header.frame_id = "map";
+    start_marker.header.frame_id = get_tf_info().map_frame;
     start_marker.name = seg.id + "_start";
     start_marker.description = "Route " + seg.id + " start";
     start_marker.pose = seg.start;
     start_marker.scale = 1.0;
 
     visualization_msgs::msg::InteractiveMarker end_marker;
-    end_marker.header.frame_id = "map";
+    end_marker.header.frame_id = get_tf_info().map_frame;
     end_marker.name = seg.id + "_end";
     end_marker.description = "Route " + seg.id + " end";
     end_marker.pose = seg.end;

--- a/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
+++ b/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
@@ -205,7 +205,7 @@ std::expected<void, std::string> RoutesMapsManager::on_initialize()
       std::shared_ptr<RoutesFilter> instance =
         routes_filters_loader_->createSharedInstance(plugin);
 
-      auto result = instance->initialize(node, plugin_name + "." + filter_name, get_tf_prefix());
+      auto result = instance->initialize(node, plugin_name + "." + filter_name, get_tf_info());
       if (!result) {
         RCLCPP_ERROR(node->get_logger(),
           "Unable to initialize RoutesFilter %s [%s]. Error: %s",

--- a/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
+++ b/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
@@ -19,6 +19,7 @@
 
 
 #include "easynav_routes_maps_manager/RoutesMapsManager.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include <expected>
 #include <fstream>
@@ -205,7 +206,7 @@ std::expected<void, std::string> RoutesMapsManager::on_initialize()
       std::shared_ptr<RoutesFilter> instance =
         routes_filters_loader_->createSharedInstance(plugin);
 
-      auto result = instance->initialize(node, plugin_name + "." + filter_name, get_tf_info());
+      auto result = instance->initialize(node, plugin_name + "." + filter_name);
       if (!result) {
         RCLCPP_ERROR(node->get_logger(),
           "Unable to initialize RoutesFilter %s [%s]. Error: %s",
@@ -386,13 +387,15 @@ void RoutesMapsManager::publish_routes_markers()
     return;
   }
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   visualization_msgs::msg::MarkerArray array;
 
    // First, delete all previous markers in our namespaces so that
    // removed segments do not leave orphaned markers behind.
   {
     visualization_msgs::msg::Marker m;
-    m.header.frame_id = get_tf_info().map_frame;
+    m.header.frame_id = tf_info.map_frame;
     m.action = visualization_msgs::msg::Marker::DELETEALL;
 
     m.ns = "routes_line";
@@ -406,7 +409,7 @@ void RoutesMapsManager::publish_routes_markers()
   for (const auto & seg : routes_) {
     // Line between start and end
     visualization_msgs::msg::Marker line;
-    line.header.frame_id = get_tf_info().map_frame;
+    line.header.frame_id = tf_info.map_frame;
     line.ns = "routes_line";
     line.id = id++;
     line.type = visualization_msgs::msg::Marker::LINE_LIST;
@@ -432,7 +435,7 @@ void RoutesMapsManager::publish_routes_markers()
 
     // Arrow for start orientation (same style as end)
     visualization_msgs::msg::Marker start_arrow;
-    start_arrow.header.frame_id = get_tf_info().map_frame;
+    start_arrow.header.frame_id = tf_info.map_frame;
     start_arrow.ns = "routes_arrow";
     start_arrow.id = id++;
     start_arrow.type = visualization_msgs::msg::Marker::ARROW;
@@ -449,7 +452,7 @@ void RoutesMapsManager::publish_routes_markers()
 
     // Arrow for end orientation (same style)
     visualization_msgs::msg::Marker end_arrow;
-    end_arrow.header.frame_id = get_tf_info().map_frame;
+    end_arrow.header.frame_id = tf_info.map_frame;
     end_arrow.ns = "routes_arrow";
     end_arrow.id = id++;
     end_arrow.type = visualization_msgs::msg::Marker::ARROW;
@@ -475,10 +478,12 @@ void RoutesMapsManager::publish_interactive_markers()
   }
   imarker_server_->clear();
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   for (const auto & seg : routes_) {
     // Per-segment toggle cube (red in normal mode, green in edit mode).
     visualization_msgs::msg::InteractiveMarker mode_marker;
-    mode_marker.header.frame_id = get_tf_info().map_frame;
+    mode_marker.header.frame_id = tf_info.map_frame;
     mode_marker.name = seg.id + "_mode";
     mode_marker.scale = 1.0;
 
@@ -540,14 +545,14 @@ void RoutesMapsManager::publish_interactive_markers()
     }
 
     visualization_msgs::msg::InteractiveMarker start_marker;
-    start_marker.header.frame_id = get_tf_info().map_frame;
+    start_marker.header.frame_id = tf_info.map_frame;
     start_marker.name = seg.id + "_start";
     start_marker.description = "Route " + seg.id + " start";
     start_marker.pose = seg.start;
     start_marker.scale = 1.0;
 
     visualization_msgs::msg::InteractiveMarker end_marker;
-    end_marker.header.frame_id = get_tf_info().map_frame;
+    end_marker.header.frame_id = tf_info.map_frame;
     end_marker.name = seg.id + "_end";
     end_marker.description = "Route " + seg.id + " end";
     end_marker.pose = seg.end;

--- a/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/filters/RoutesCostmapFilter.cpp
+++ b/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/filters/RoutesCostmapFilter.cpp
@@ -39,12 +39,11 @@ std::expected<void, std::string>
 RoutesCostmapFilter::initialize(
   const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
   const std::string & plugin_ns,
-  const std::string & tf_prefix)
+  const TFInfo & tf_info)
 {
   node_ = node;
   plugin_ns_ = plugin_ns;
-  tf_prefix_ = tf_prefix;
-
+  tf_info_ = tf_info;
   // Parameter for minimum cost to apply outside routes
   if (!node->has_parameter(plugin_ns_ + ".min_cost")) {
     node->declare_parameter(plugin_ns_ + ".min_cost", min_cost_);
@@ -182,7 +181,7 @@ RoutesCostmapFilter::update(NavState & nav_state)
   }
 
   costmap.toOccupancyGridMsg(routes_grid_msg_);
-  routes_grid_msg_.header.frame_id = tf_prefix_ + "map";
+  routes_grid_msg_.header.frame_id = tf_info_.map_frame;
   if (auto node_locked = node_.lock()) {
     routes_grid_msg_.header.stamp = node_locked->now();
   }

--- a/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/filters/RoutesCostmapFilter.cpp
+++ b/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/filters/RoutesCostmapFilter.cpp
@@ -30,6 +30,8 @@
 
 #include "easynav_routes_maps_manager/RoutesMapsManager.hpp"
 
+#include "easynav_common/RTTFBuffer.hpp"
+
 namespace easynav
 {
 
@@ -38,12 +40,10 @@ RoutesCostmapFilter::RoutesCostmapFilter() = default;
 std::expected<void, std::string>
 RoutesCostmapFilter::initialize(
   const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
-  const std::string & plugin_ns,
-  const TFInfo & tf_info)
+  const std::string & plugin_ns)
 {
   node_ = node;
   plugin_ns_ = plugin_ns;
-  tf_info_ = tf_info;
   // Parameter for minimum cost to apply outside routes
   if (!node->has_parameter(plugin_ns_ + ".min_cost")) {
     node->declare_parameter(plugin_ns_ + ".min_cost", min_cost_);
@@ -181,7 +181,7 @@ RoutesCostmapFilter::update(NavState & nav_state)
   }
 
   costmap.toOccupancyGridMsg(routes_grid_msg_);
-  routes_grid_msg_.header.frame_id = tf_info_.map_frame;
+  routes_grid_msg_.header.frame_id = RTTFBuffer::getInstance()->get_tf_info().map_frame;
   if (auto node_locked = node_.lock()) {
     routes_grid_msg_.header.stamp = node_locked->now();
   }

--- a/maps_managers/easynav_routes_maps_manager/tests/routes_costmap_filter_tests.cpp
+++ b/maps_managers/easynav_routes_maps_manager/tests/routes_costmap_filter_tests.cpp
@@ -55,7 +55,8 @@ TEST_F(RoutesCostmapFilterTest, DoesNothingWhenNavStateMissingKeys)
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("routes_costmap_filter_missing");
 
   RoutesCostmapFilter filter;
-  auto init_result = filter.initialize(node, "routes.routes_costmap", "");
+  easynav::TFInfo tf_info;
+  auto init_result = filter.initialize(node, "routes.routes_costmap", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   NavState nav_state;
@@ -68,7 +69,8 @@ TEST_F(RoutesCostmapFilterTest, RaisesCostOutsideRoutes)
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("routes_costmap_filter_basic");
 
   RoutesCostmapFilter filter;
-  auto init_result = filter.initialize(node, "routes.routes_costmap", "");
+  easynav::TFInfo tf_info;
+  auto init_result = filter.initialize(node, "routes.routes_costmap", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   // Simple costmap 10x1, resolution 1.0, origin at (0,0)
@@ -116,7 +118,8 @@ TEST_F(RoutesCostmapFilterTest, IgnoresRoutePointsOutsideMap)
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("routes_costmap_filter_outside");
 
   RoutesCostmapFilter filter;
-  auto init_result = filter.initialize(node, "routes.routes_costmap", "");
+  easynav::TFInfo tf_info;
+  auto init_result = filter.initialize(node, "routes.routes_costmap", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   // Costmap 5x1 from x=0..5

--- a/maps_managers/easynav_routes_maps_manager/tests/routes_costmap_filter_tests.cpp
+++ b/maps_managers/easynav_routes_maps_manager/tests/routes_costmap_filter_tests.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include "easynav_common/types/NavState.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "easynav_costmap_common/costmap_2d.hpp"
 
@@ -56,7 +57,9 @@ TEST_F(RoutesCostmapFilterTest, DoesNothingWhenNavStateMissingKeys)
 
   RoutesCostmapFilter filter;
   easynav::TFInfo tf_info;
-  auto init_result = filter.initialize(node, "routes.routes_costmap", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  auto init_result = filter.initialize(node, "routes.routes_costmap");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   NavState nav_state;
@@ -70,7 +73,9 @@ TEST_F(RoutesCostmapFilterTest, RaisesCostOutsideRoutes)
 
   RoutesCostmapFilter filter;
   easynav::TFInfo tf_info;
-  auto init_result = filter.initialize(node, "routes.routes_costmap", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  auto init_result = filter.initialize(node, "routes.routes_costmap");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   // Simple costmap 10x1, resolution 1.0, origin at (0,0)
@@ -119,7 +124,9 @@ TEST_F(RoutesCostmapFilterTest, IgnoresRoutePointsOutsideMap)
 
   RoutesCostmapFilter filter;
   easynav::TFInfo tf_info;
-  auto init_result = filter.initialize(node, "routes.routes_costmap", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  auto init_result = filter.initialize(node, "routes.routes_costmap");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   // Costmap 5x1 from x=0..5

--- a/maps_managers/easynav_routes_maps_manager/tests/routes_mapsmanager_tests.cpp
+++ b/maps_managers/easynav_routes_maps_manager/tests/routes_mapsmanager_tests.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 
 #include "easynav_common/types/NavState.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "easynav_routes_maps_manager/RoutesMapsManager.hpp"
 
@@ -89,7 +90,9 @@ TEST_F(RoutesMapsManagerTest, LoadsRoutesFromValidYaml)
 
   auto manager = std::make_shared<RoutesMapsManager>();
   easynav::TFInfo tf_info;
-  auto init_result = manager->initialize(node, "routes", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  auto init_result = manager->initialize(node, "routes");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -116,7 +119,8 @@ TEST_F(RoutesMapsManagerTest, DefaultRouteWhenMapPathEmpty)
 
   auto manager = std::make_shared<RoutesMapsManager>();
   easynav::TFInfo tf_info;
-  auto init_result = manager->initialize(node, "routes", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+  auto init_result = manager->initialize(node, "routes");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -142,7 +146,8 @@ TEST_F(RoutesMapsManagerTest, DefaultRouteWhenYamlMissing)
 
   auto manager = std::make_shared<RoutesMapsManager>();
   easynav::TFInfo tf_info;
-  auto init_result = manager->initialize(node, "routes", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+  auto init_result = manager->initialize(node, "routes");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -169,7 +174,8 @@ TEST_F(RoutesMapsManagerTest, DefaultRouteWhenNoRoutesKey)
 
   auto manager = std::make_shared<RoutesMapsManager>();
   easynav::TFInfo tf_info;
-  auto init_result = manager->initialize(node, "routes", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+  auto init_result = manager->initialize(node, "routes");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -201,7 +207,9 @@ TEST_F(RoutesMapsManagerTest, UpdateWritesRoutesIntoNavState)
 
   auto manager = std::make_shared<RoutesMapsManager>();
   easynav::TFInfo tf_info;
-  auto init_result = manager->initialize(node, "routes", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  auto init_result = manager->initialize(node, "routes");
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   easynav::NavState nav_state;

--- a/maps_managers/easynav_routes_maps_manager/tests/routes_mapsmanager_tests.cpp
+++ b/maps_managers/easynav_routes_maps_manager/tests/routes_mapsmanager_tests.cpp
@@ -88,7 +88,8 @@ TEST_F(RoutesMapsManagerTest, LoadsRoutesFromValidYaml)
   });
 
   auto manager = std::make_shared<RoutesMapsManager>();
-  auto init_result = manager->initialize(node, "routes");
+  easynav::TFInfo tf_info;
+  auto init_result = manager->initialize(node, "routes", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -114,7 +115,8 @@ TEST_F(RoutesMapsManagerTest, DefaultRouteWhenMapPathEmpty)
   });
 
   auto manager = std::make_shared<RoutesMapsManager>();
-  auto init_result = manager->initialize(node, "routes");
+  easynav::TFInfo tf_info;
+  auto init_result = manager->initialize(node, "routes", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -139,7 +141,8 @@ TEST_F(RoutesMapsManagerTest, DefaultRouteWhenYamlMissing)
   });
 
   auto manager = std::make_shared<RoutesMapsManager>();
-  auto init_result = manager->initialize(node, "routes");
+  easynav::TFInfo tf_info;
+  auto init_result = manager->initialize(node, "routes", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -165,7 +168,8 @@ TEST_F(RoutesMapsManagerTest, DefaultRouteWhenNoRoutesKey)
   });
 
   auto manager = std::make_shared<RoutesMapsManager>();
-  auto init_result = manager->initialize(node, "routes");
+  easynav::TFInfo tf_info;
+  auto init_result = manager->initialize(node, "routes", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   const auto & routes = manager->get_routes();
@@ -196,7 +200,8 @@ TEST_F(RoutesMapsManagerTest, UpdateWritesRoutesIntoNavState)
   });
 
   auto manager = std::make_shared<RoutesMapsManager>();
-  auto init_result = manager->initialize(node, "routes");
+  easynav::TFInfo tf_info;
+  auto init_result = manager->initialize(node, "routes", tf_info);
   ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
   easynav::NavState nav_state;

--- a/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
+++ b/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
@@ -86,15 +86,17 @@ SimpleMapsManager::on_initialize()
   dynamic_occ_pub_ = node->create_publisher<nav_msgs::msg::OccupancyGrid>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/dynamic_map", 100);
 
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
+
   incoming_map_sub_ = node->create_subscription<nav_msgs::msg::OccupancyGrid>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/incoming_map",
     rclcpp::QoS(1).transient_local().reliable(),
-    [this](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
+    [&](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
       static_map_.from_occupancy_grid(*msg);
       dynamic_map_.from_occupancy_grid(*msg);
 
       static_map_.to_occupancy_grid(static_grid_msg_);
-      static_grid_msg_.header.frame_id = get_tf_info().map_frame;
+      static_grid_msg_.header.frame_id = tf_info.map_frame;
       static_grid_msg_.header.stamp = this->get_node()->now();
 
       static_occ_pub_->publish(static_grid_msg_);
@@ -102,7 +104,7 @@ SimpleMapsManager::on_initialize()
 
   savemap_srv_ = node->create_service<std_srvs::srv::Trigger>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/savemap",
-    [this](
+    [&](
       const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
       std::shared_ptr<std_srvs::srv::Trigger::Response> response)
     {
@@ -117,7 +119,7 @@ SimpleMapsManager::on_initialize()
     });
 
   static_map_.to_occupancy_grid(static_grid_msg_);
-  static_grid_msg_.header.frame_id = get_tf_info().map_frame;
+  static_grid_msg_.header.frame_id = tf_info.map_frame;
   static_grid_msg_.header.stamp = node->now();
 
   static_occ_pub_->publish(static_grid_msg_);
@@ -151,10 +153,11 @@ SimpleMapsManager::update(NavState & nav_state)
   }
 
   const auto & perceptions = nav_state.get<PointPerceptions>("points");
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(dynamic_map_.resolution())
-    .fuse(get_tf_info().map_frame)
+    .fuse(tf_info.map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .as_points();
 
@@ -169,7 +172,7 @@ SimpleMapsManager::update(NavState & nav_state)
   nav_state.set("map.dynamic", dynamic_map_);
 
   dynamic_map_.to_occupancy_grid(dynamic_grid_msg_);
-  dynamic_grid_msg_.header.frame_id = get_tf_info().map_frame;
+  dynamic_grid_msg_.header.frame_id = tf_info.map_frame;
   dynamic_grid_msg_.header.stamp = get_node()->now();
   dynamic_occ_pub_->publish(dynamic_grid_msg_);
 }

--- a/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
+++ b/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
@@ -94,7 +94,7 @@ SimpleMapsManager::on_initialize()
       dynamic_map_.from_occupancy_grid(*msg);
 
       static_map_.to_occupancy_grid(static_grid_msg_);
-      static_grid_msg_.header.frame_id = get_tf_prefix() + "map";
+      static_grid_msg_.header.frame_id = get_tf_info().map_frame;
       static_grid_msg_.header.stamp = this->get_node()->now();
 
       static_occ_pub_->publish(static_grid_msg_);
@@ -117,7 +117,7 @@ SimpleMapsManager::on_initialize()
     });
 
   static_map_.to_occupancy_grid(static_grid_msg_);
-  static_grid_msg_.header.frame_id = get_tf_prefix() + "map";
+  static_grid_msg_.header.frame_id = get_tf_info().map_frame;
   static_grid_msg_.header.stamp = node->now();
 
   static_occ_pub_->publish(static_grid_msg_);
@@ -154,7 +154,7 @@ SimpleMapsManager::update(NavState & nav_state)
 
   auto fused = PointPerceptionsOpsView(perceptions)
     .downsample(dynamic_map_.resolution())
-    .fuse(get_tf_prefix() + "map")
+    .fuse(get_tf_info().map_frame)
     .filter({NAN, NAN, 0.1}, {NAN, NAN, NAN})
     .as_points();
 
@@ -169,7 +169,7 @@ SimpleMapsManager::update(NavState & nav_state)
   nav_state.set("map.dynamic", dynamic_map_);
 
   dynamic_map_.to_occupancy_grid(dynamic_grid_msg_);
-  dynamic_grid_msg_.header.frame_id = get_tf_prefix() + "map";
+  dynamic_grid_msg_.header.frame_id = get_tf_info().map_frame;
   dynamic_grid_msg_.header.stamp = get_node()->now();
   dynamic_occ_pub_->publish(dynamic_grid_msg_);
 }

--- a/maps_managers/easynav_simple_maps_manager/tests/simple_mapsmanager_tests.cpp
+++ b/maps_managers/easynav_simple_maps_manager/tests/simple_mapsmanager_tests.cpp
@@ -66,7 +66,11 @@ TEST_F(SimpleMapsManagerTest, BasicDynamicUpdate)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_node");
   auto manager = std::make_shared<easynav::SimpleMapsManager>();
-  manager->initialize(node, "test");
+  easynav::TFInfo tf_info;
+  tf_info.map_frame = "world_map";
+  tf_info.odom_frame = "world_odom";
+  tf_info.robot_frame = "world_base";
+  manager->initialize(node, "test", tf_info);
 
   auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
   tf2_ros::TransformListener tf_listener(*tf_buffer, *node, true);
@@ -124,7 +128,11 @@ TEST_F(SimpleMapsManagerTest, IncomingOccupancyGridUpdatesMaps)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_node2");
   auto manager = std::make_shared<easynav::SimpleMapsManager>();
-  manager->initialize(node, "test2");
+  easynav::TFInfo tf_info;
+  tf_info.map_frame = "world_map";
+  tf_info.odom_frame = "world_odom";
+  tf_info.robot_frame = "world_base";
+  manager->initialize(node, "test2", tf_info);
 
   easynav::NavState navstate;
 
@@ -136,7 +144,7 @@ TEST_F(SimpleMapsManagerTest, IncomingOccupancyGridUpdatesMaps)
     "test_node2/test2/incoming_map", rclcpp::QoS(1).transient_local().reliable());
 
   nav_msgs::msg::OccupancyGrid grid;
-  grid.header.frame_id = "map";
+  grid.header.frame_id = tf_info.map_frame;
   grid.info.width = 10;
   grid.info.height = 10;
   grid.info.resolution = 0.2;
@@ -167,7 +175,11 @@ TEST_F(SimpleMapsManagerTest, SavemapServiceWorks)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_savemap_node");
   auto manager = std::make_shared<easynav::SimpleMapsManager>();
-  manager->initialize(node, "test_savemap");
+  easynav::TFInfo tf_info;
+  tf_info.map_frame = "world_map";
+  tf_info.odom_frame = "world_odom";
+  tf_info.robot_frame = "world_base";
+  manager->initialize(node, "test_savemap", tf_info);
 
   easynav::SimpleMap map_static;
   map_static.initialize(4, 4, 0.5, -1.0, -1.0, 0);

--- a/maps_managers/easynav_simple_maps_manager/tests/simple_mapsmanager_tests.cpp
+++ b/maps_managers/easynav_simple_maps_manager/tests/simple_mapsmanager_tests.cpp
@@ -70,7 +70,9 @@ TEST_F(SimpleMapsManagerTest, BasicDynamicUpdate)
   tf_info.map_frame = "world_map";
   tf_info.odom_frame = "world_odom";
   tf_info.robot_frame = "world_base";
-  manager->initialize(node, "test", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  manager->initialize(node, "test");
 
   auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
   tf2_ros::TransformListener tf_listener(*tf_buffer, *node, true);
@@ -132,7 +134,9 @@ TEST_F(SimpleMapsManagerTest, IncomingOccupancyGridUpdatesMaps)
   tf_info.map_frame = "world_map";
   tf_info.odom_frame = "world_odom";
   tf_info.robot_frame = "world_base";
-  manager->initialize(node, "test2", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  manager->initialize(node, "test2");
 
   easynav::NavState navstate;
 
@@ -179,7 +183,9 @@ TEST_F(SimpleMapsManagerTest, SavemapServiceWorks)
   tf_info.map_frame = "world_map";
   tf_info.odom_frame = "world_odom";
   tf_info.robot_frame = "world_base";
-  manager->initialize(node, "test_savemap", tf_info);
+  easynav::RTTFBuffer::getInstance()->set_tf_info(tf_info);
+
+  manager->initialize(node, "test_savemap");
 
   easynav::SimpleMap map_static;
   map_static.initialize(4, 4, 0.5, -1.0, -1.0, 0);

--- a/planners/easynav_costmap_planner/README.md
+++ b/planners/easynav_costmap_planner/README.md
@@ -31,11 +31,53 @@ All parameters are declared under the plugin namespace, i.e., `/<node_fqn>/easyn
 
 | Name | Type | Default | Description |
 |---|---|---:|---|
-| `<plugin>.cost_factor` | `double` | `2.0` | Scaling factor applied to costmap cell values to compute traversal costs. |
+| `<plugin>.cost_factor` | `double` | `2.0` | Scaling factor applied to costmap cell values to compute traversal costs. Higher values make high-cost cells much less attractive. |
 | `<plugin>.inflation_penalty` | `double` | `5.0` | Extra penalty added to inflated/near-obstacle cells to push paths away from obstacles. |
-| `<plugin>.cost_axial` | `double` | `1.0` | Base movement cost for axial (N/E/S/W) steps. |
-| `<plugin>.cost_diagonal` | `double` | `1.41` | Base movement cost for diagonal steps (approx. √2). |
+| `<plugin>.heuristic_scale` | `double` | `1.0` | Scaling factor applied to the A* heuristic term. Controls the trade-off between following the cheapest route vs. going more directly. |
 | `<plugin>.continuous_replan` | `bool` | `true` | If `true`, re-plans continuously as the map/goal changes; if `false`, plans once per request. |
+
+### Effect of `cost_factor`
+
+The planner uses a per-step traversal cost:
+
+$$
+g_{\text{new}} = g_{\text{current}} + \text{step\_cost} \cdot \left(1 + \text{cost\_factor} \cdot \frac{\text{cell\_cost}}{\text{LETHAL\_OBSTACLE}}\right)
+$$
+
+- **Low `cost_factor` (e.g. 1–2):**
+	- Cell cost has a modest influence; the planner is closer to a pure geometric shortest-path search.
+	- Paths may cross moderately expensive regions if that keeps distance short.
+- **High `cost_factor` (e.g. 5–10+):**
+	- High-cost cells become very unattractive, so the planner strongly prefers low-cost corridors (e.g. routes or low-inflation areas), even if they are longer.
+	- Useful when combined with modules that encode preferences as higher costs (such as route managers).
+
+### Effect of `heuristic_scale`
+
+The A* priority is:
+
+$$
+f = g + h, \quad h = \text{heuristic\_scale} \cdot d_{\text{cells}}(\text{current}, \text{goal})
+$$
+
+where $d_{\text{cells}}$ is the Euclidean distance in cell indices (not metric distance, but proportional).
+
+- **Decrease `heuristic_scale` (< 1.0):**
+	- The heuristic term becomes weaker, and A* behaves more like Dijkstra.
+	- The search explores more alternatives and is guided more strictly by the true accumulated cost $g$.
+	- This usually makes the planner follow high-cost penalties (e.g. for leaving a route) more faithfully, at the expense of more computation.
+
+- **Increase `heuristic_scale` (> 1.0):**
+	- The heuristic term dominates more, so the planner prefers geometrically direct paths.
+	- It may still avoid extremely high-cost regions if `cost_factor` is large, but will be more willing to “cut corners” through slightly more expensive zones.
+
+**Typical tuning strategy:**
+
+- First, adjust `cost_factor` so that the costmap properly encodes your preferences:
+	- Increase it until paths clearly avoid high-cost areas that should be disfavored.
+- Then, fine-tune `heuristic_scale`:
+	- Start from `1.0`.
+	- If the planner still takes shortcuts that ignore cost differences, consider reducing it slightly (e.g. `0.7–0.9`).
+	- If planning becomes too slow or explores too widely, you can increase it modestly (e.g. `1.2–1.5`).
 
 ---
 

--- a/planners/easynav_costmap_planner/include/easynav_costmap_planner/CostmapPlanner.hpp
+++ b/planners/easynav_costmap_planner/include/easynav_costmap_planner/CostmapPlanner.hpp
@@ -70,8 +70,7 @@ public:
 protected:
   double cost_factor_;        ///< Scaling factor applied to cell cost values.
   double inflation_penalty_; ///< Extra cost penalty for paths near inflated obstacles.
-  double cost_axial_;        ///< Cost multiplier for axial (horizontal/vertical) moves.
-  double cost_diagonal_;     ///< Cost multiplier for diagonal moves.
+  double heuristic_scale_ {1.0}; ///< Scaling factor applied to the heuristic term in A*.
   bool continuous_replan_ {true};    ///< Wheter replan path at freq time
   nav_msgs::msg::Path current_path_;  ///< Most recently computed path.
   geometry_msgs::msg::Pose current_goal_;  ///< Current goal.

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -128,15 +128,12 @@ std::expected<void, std::string> CostmapPlanner::on_initialize()
   const auto & plugin_name = get_plugin_name();
   node->declare_parameter<double>(plugin_name + ".cost_factor", 2.0);
   node->declare_parameter<double>(plugin_name + ".inflation_penalty", 5.0);
-  node->declare_parameter<double>(plugin_name + ".cost_axial", 1.0);
-  node->declare_parameter<double>(plugin_name + ".cost_diagonal", 1.41);
+  node->declare_parameter<double>(plugin_name + ".heuristic_scale", 1.0);
   node->declare_parameter<bool>(plugin_name + ".continuous_replan", true);
 
   node->get_parameter(plugin_name + ".cost_factor", cost_factor_);
   node->get_parameter(plugin_name + ".inflation_penalty", inflation_penalty_);
-  node->get_parameter(plugin_name + ".cost_axial", cost_axial_);
-  node->get_parameter(plugin_name + ".cost_diagonal", cost_diagonal_);
-  node->get_parameter(plugin_name + ".cost_diagonal", cost_diagonal_);
+  node->get_parameter(plugin_name + ".heuristic_scale", heuristic_scale_);
   node->get_parameter(plugin_name + ".continuous_replan", continuous_replan_);
 
   path_pub_ = node->create_publisher<nav_msgs::msg::Path>(
@@ -259,8 +256,8 @@ std::vector<geometry_msgs::msg::Pose> CostmapPlanner::a_star_path(
   int width = map.getSizeInCellsX();
   // Precompute constants used inside the neighbor loop
   const double lethal_norm = 1.0 / static_cast<double>(LETHAL_OBSTACLE);
-  const double axial_cost = cost_axial_;
-  const double diagonal_cost = cost_diagonal_;
+  const double axial_cost = 1.0;
+  const double diagonal_cost = std::sqrt(2.0);
   auto idx = [&](int x, int y) {return y * width + x;};
 
   std::priority_queue<GridNode, std::vector<GridNode>, std::greater<>> open;
@@ -271,7 +268,9 @@ std::vector<geometry_msgs::msg::Pose> CostmapPlanner::a_star_path(
   std::vector<int> parent_y(total_cells, -1);
   std::vector<double> cost_so_far(total_cells, std::numeric_limits<double>::infinity());
 
-  open.push(GridNode{static_cast<int>(sx), static_cast<int>(sy), 0.0, heuristic(sx, sy, gx, gy)});
+  const double initial_h = heuristic(static_cast<int>(sx), static_cast<int>(sy),
+      static_cast<int>(gx), static_cast<int>(gy)) * heuristic_scale_;
+  open.push(GridNode{static_cast<int>(sx), static_cast<int>(sy), 0.0, initial_h});
   cost_so_far[idx(sx, sy)] = 0.0;
 
   while (!open.empty()) {
@@ -297,7 +296,9 @@ std::vector<geometry_msgs::msg::Pose> CostmapPlanner::a_star_path(
 
       if (new_cost < cost_so_far[nid]) {
         cost_so_far[nid] = new_cost;
-        open.push(GridNode{nx, ny, new_cost, new_cost + heuristic(nx, ny, gx, gy)});
+        const double h = heuristic(nx, ny, static_cast<int>(gx), static_cast<int>(gy)) *
+          heuristic_scale_;
+        open.push(GridNode{nx, ny, new_cost, new_cost + h});
         parent_x[nid] = current.x;
         parent_y[nid] = current.y;
       }

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -160,7 +160,7 @@ void CostmapPlanner::update(NavState & nav_state)
   const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
 
-  if (goals.header.frame_id != get_tf_prefix() + "map") {
+  if (goals.header.frame_id != get_tf_info().map_frame) {
     RCLCPP_WARN(get_node()->get_logger(), "Goals frame is not 'map': %s",
         goals.header.frame_id.c_str());
     return;

--- a/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
+++ b/planners/easynav_costmap_planner/src/easynav_costmap_planner/CostmapPlanner.cpp
@@ -26,6 +26,7 @@
 #include <tuple>
 
 #include "easynav_costmap_planner/CostmapPlanner.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "nav_msgs/msg/goals.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -156,8 +157,9 @@ void CostmapPlanner::update(NavState & nav_state)
   const auto & map = nav_state.get<Costmap2D>("map.dynamic");
   const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
-  if (goals.header.frame_id != get_tf_info().map_frame) {
+  if (goals.header.frame_id != tf_info.map_frame) {
     RCLCPP_WARN(get_node()->get_logger(), "Goals frame is not 'map': %s",
         goals.header.frame_id.c_str());
     return;

--- a/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
+++ b/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
@@ -96,7 +96,7 @@ void AStarPlanner::update(NavState & nav_state)
   const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
 
-  if (goals.header.frame_id != get_tf_prefix() + "map") {
+  if (goals.header.frame_id != get_tf_info().map_frame) {
     RCLCPP_WARN(
       get_node()->get_logger(), "Goals frame is not 'map': %s",
       goals.header.frame_id.c_str());

--- a/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
+++ b/planners/easynav_navmap_planner/src/easynav_navmap_planner/AStarPlanner.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstdint>
 
+#include "easynav_common/RTTFBuffer.hpp"
 #include "easynav_navmap_planner/AStarPlanner.hpp"
 
 #include "nav_msgs/msg/goals.hpp"
@@ -95,8 +96,9 @@ void AStarPlanner::update(NavState & nav_state)
 
   const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
-  if (goals.header.frame_id != get_tf_info().map_frame) {
+  if (goals.header.frame_id != tf_info.map_frame) {
     RCLCPP_WARN(
       get_node()->get_logger(), "Goals frame is not 'map': %s",
       goals.header.frame_id.c_str());

--- a/planners/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
+++ b/planners/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 
 #include "easynav_simple_planner/SimplePlanner.hpp"
+#include "easynav_common/RTTFBuffer.hpp"
 
 #include "nav_msgs/msg/goals.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -132,10 +133,11 @@ SimplePlanner::update(NavState & nav_state)
 
   const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
   const auto & goal = goals.goals.front().pose;
+  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
 
   auto downsampled_map = map_typed.downsample(0.2);
 
-  if (goals.header.frame_id != get_tf_info().map_frame) {
+  if (goals.header.frame_id != tf_info.map_frame) {
     RCLCPP_WARN(get_node()->get_logger(),
       "SimplePlanner::update goals frame is not map (%s)", goals.header.frame_id.c_str());
     return;

--- a/planners/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
+++ b/planners/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
@@ -135,7 +135,7 @@ SimplePlanner::update(NavState & nav_state)
 
   auto downsampled_map = map_typed.downsample(0.2);
 
-  if (goals.header.frame_id != "map") {
+  if (goals.header.frame_id != get_tf_info().map_frame) {
     RCLCPP_WARN(get_node()->get_logger(),
       "SimplePlanner::update goals frame is not map (%s)", goals.header.frame_id.c_str());
     return;


### PR DESCRIPTION
Fixed frames names in fusion_localizer for  [PR 40](https://github.com/EasyNavigation/easynav_plugins/pull/40)
Robot_localiztion can work as a local filter if world_frame is set as odom or as a global filter if world frame is map.
I set all world frames to map for this version that only includes a global filter.