### PR TITLE
Costmap MM adapted to support exploration

### DIFF
--- a/maps_managers/easynav_costmap_maps_manager/include/easynav_costmap_maps_manager/CostmapMapsManager.hpp
+++ b/maps_managers/easynav_costmap_maps_manager/include/easynav_costmap_maps_manager/CostmapMapsManager.hpp
@@ -88,12 +88,16 @@ protected:
 
 private:
   /**
+   * @brief Internal flag to change navstate
+   */
+  bool update_map_static_ = false;
+  /**
    * @brief Internal static map.
    */
   Costmap2D static_map_;
 
   /**
-   * @brief Internal static map.
+   * @brief Internal dynamic map.
    */
   std::shared_ptr<Costmap2D> dynamic_map_;
 

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
@@ -140,6 +140,7 @@ CostmapMapsManager::on_initialize()
       static_grid_msg_.header.stamp = this->get_node()->now();
 
       static_occ_pub_->publish(static_grid_msg_);
+      update_map_static_ = true;
     });
 
   savemap_srv_ = node->create_service<std_srvs::srv::Trigger>(
@@ -179,8 +180,10 @@ CostmapMapsManager::update(NavState & nav_state)
 {
   EASYNAV_TRACE_EVENT;
 
-  if (!nav_state.has("map.static")) {
+  // Set static map at beggining or when a new static map arrives
+  if (update_map_static_ || !nav_state.has("map.static")) {
     nav_state.set("map.static", static_map_);
+    update_map_static_ = false;
   }
 
   if (!dynamic_map_) {


### PR DESCRIPTION
CostMap MapsManager static map private variable is now up-to-date with navstate saved static map. Navstate static map was setted once at the beggining and never changed, what made impossible explore without a previous complete map file. Tests passed.