### PR TITLE
Fix rolling CI

### DIFF
--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -12,18 +12,16 @@ on:
   workflow_dispatch:
 jobs:
   build-and-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
-      image: ubuntu:noble
+      image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-resolute-ros-rolling-ros-base:master
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v6-beta
+        uses: actions/checkout@v6
         with:
           ref: rolling
-      - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@0.7.15
       - name: build and test
-        uses: ros-tooling/action-ros-ci@0.4.5
+        uses: ros-tooling/action-ros-ci@0.4.8
         with:
           package-name: easynav_common easynav_controller easynav_core easynav_interfaces easynav_localizer easynav_maps_manager easynav_planner easynav_sensors easynav_support_py easynav_system easynav_tools easynav_bonxai_maps_manager easynav_costmap_common easynav_costmap_localizer easynav_costmap_maps_manager easynav_costmap_planner easynav_gps_localizer easynav_fusion_localizer easynav_mppi_controller easynav_navmap_localizer easynav_navmap_maps_manager easynav_navmap_planner easynav_serest_controller easynav_simple_common easynav_simple_controller easynav_simple_localizer easynav_simple_maps_manager easynav_simple_planner easynav_vff_controller easynav_mpc_controller
           target-ros2-distro: rolling

--- a/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
+++ b/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
@@ -27,7 +27,7 @@
 #include "pcl/point_types.h"
 #include "pcl/point_cloud.h"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace easynav_bonxai
@@ -73,7 +73,7 @@ BonxaiMapsManager::on_initialize()
 
   if (!package_name.empty() && !bonxai_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+      const std::string pkgpath = ament_index_cpp::get_package_share_path(package_name);
       map_path_ = pkgpath + std::string("/") + bonxai_path_file;
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
@@ -106,7 +106,7 @@ BonxaiMapsManager::on_initialize()
 
   if (!package_name.empty() && !occmap_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+      const std::string pkgpath = ament_index_cpp::get_package_share_path(package_name);
       map_path_ = pkgpath + std::string("/") + occmap_path_file;
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
@@ -24,7 +24,7 @@
 #include "easynav_costmap_maps_manager/map_io.hpp"
 #include "easynav_common/RTTFBuffer.hpp"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace easynav
@@ -110,7 +110,7 @@ CostmapMapsManager::on_initialize()
   map_path_ = "/tmp/default.map.yaml";
   if (!package_name.empty() && !map_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+      const std::string pkgpath = ament_index_cpp::get_package_share_path(package_name);
       map_path_ = pkgpath + std::string("/") + map_path_file;
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
@@ -26,7 +26,7 @@
 #include "navmap_ros/navmap_io.hpp"
 #include "easynav_navmap_maps_manager/map_io.hpp"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace easynav
@@ -122,7 +122,7 @@ NavMapMapsManager::on_initialize()
 
   if (!package_name.empty() && !occmap_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+      const std::string pkgpath = ament_index_cpp::get_package_share_path(package_name);
       map_path_ = pkgpath + std::string("/") + occmap_path_file;
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
@@ -145,7 +145,7 @@ NavMapMapsManager::on_initialize()
 
   if (!package_name.empty() && !navmap_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+      const std::string pkgpath = ament_index_cpp::get_package_share_path(package_name);
       map_path_ = pkgpath + std::string("/") + navmap_path_file;
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
@@ -29,7 +29,7 @@
 #include "pcl/point_cloud.h"
 #include "pcl/filters/voxel_grid.h"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace easynav
@@ -113,7 +113,7 @@ OctomapMapsManager::on_initialize()
 
 //   if (!package_name.empty() && !occmap_path_file.empty()) {
 //     try {
-//       const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+//       const std::string pkgpath = ament_index_cpp::get_package_share_path(package_name);
 //       map_path_ = pkgpath + std::string("/") + occmap_path_file;
 //     } catch (ament_index_cpp::PackageNotFoundError & ex) {
 //       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
@@ -136,7 +136,7 @@ OctomapMapsManager::on_initialize()
 //
 //   if (!package_name.empty() && !octomap_path_file.empty()) {
 //     try {
-//       const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+//       const std::string pkgpath = ament_index_cpp::get_package_share_path(package_name);
 //       map_path_ = pkgpath + std::string("/") + occmap_path_file;
 //     } catch (ament_index_cpp::PackageNotFoundError & ex) {
 //       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());

--- a/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
+++ b/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
@@ -21,7 +21,7 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -84,8 +84,8 @@ void RoutesMapsManager::on_initialize()
     // Absolute path: ignore package_name.
     map_path_ = map_path_file;
   } else if (!package_name.empty() && !map_path_file.empty()) {
-    const auto pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-    map_path_ = pkgpath + "/" + map_path_file;
+    const auto pkgpath = ament_index_cpp::get_package_share_path(package_name);
+    map_path_ = pkgpath / map_path_file;
   } else {
     throw std::runtime_error(
       "Parameters '" + plugin_name + ".package' and '" + plugin_name +

--- a/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
+++ b/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
@@ -19,7 +19,7 @@
 #include "easynav_simple_maps_manager/SimpleMapsManager.hpp"
 #include "easynav_sensors/types/PointPerception.hpp"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 #include "easynav_common/YTSession.hpp"
@@ -62,7 +62,7 @@ SimpleMapsManager::on_initialize()
   if (package_name != "" && map_path_file != "") {
     std::string pkgpath;
     try {
-      pkgpath = ament_index_cpp::get_package_share_directory(package_name);
+      pkgpath = ament_index_cpp::get_package_share_path(package_name);
       map_path_ = pkgpath + "/" + map_path_file;
     } catch(ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());


### PR DESCRIPTION
Hi all,

This PR fixes the CI in rolling by moving to a different container using Ubuntu 26 via https://github.com/ros-tooling/setup-ros-docker containers.

I did also fixed an error coming from the `ament_index_cpp::get_package_share_directory(...)` function which is now deprecated. The new way is `ament_index_cpp::get_package_share_path(...)` which returns an `std::filesystem::path` instead of a `std::string`.


After going back to a working CI, I found a runtime error in some test files that use `std::normal_distribution` with zero std (which seems to be undefined behavior). I will open an issue now and maybe provide a fix later.