### PR TITLE
Fix CI: Add temporally robot_localization to thirdparty

### DIFF
--- a/.github/thirdparty.repos
+++ b/.github/thirdparty.repos
@@ -11,3 +11,11 @@ repositories:
     type: git
     url: https://github.com/EasyNavigation/NavMap.git
     version: rolling
+  # robot_localization has no released .deb for rolling yet (buildfarm
+  # job is failing despite the rosdistro entry), so it is built from
+  # source here. rosdep --ignore-src will skip it once it's in src/.
+  # Remove this entry once ros-rolling-robot-localization is installable again.
+  ThirdParty/robot_localization:
+    type: git
+    url: https://github.com/cra-ros-pkg/robot_localization.git
+    version: rolling-devel


### PR DESCRIPTION
Hi,

robot_localization seems temporarlly not availbale on rolling from binary, so we add it for being built from sources. Remove it as soon as it became available.

Best
