### PR TITLE
Remove deprecated get_package_share_directory

### DIFF
--- a/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
+++ b/maps_managers/easynav_bonxai_maps_manager/src/easynav_bonxai_maps_manager/BonxaiMapsManager.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <string>
 
 #include "easynav_bonxai_maps_manager/BonxaiMapsManager.hpp"
@@ -27,7 +28,7 @@
 #include "pcl/point_types.h"
 #include "pcl/point_cloud.h"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace easynav_bonxai
@@ -73,8 +74,8 @@ BonxaiMapsManager::on_initialize()
 
   if (!package_name.empty() && !bonxai_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-      map_path_ = pkgpath + std::string("/") + bonxai_path_file;
+      const std::filesystem::path pkgpath = ament_index_cpp::get_package_share_path(package_name);
+      map_path_ = (pkgpath / bonxai_path_file).string();
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
     }
@@ -106,8 +107,8 @@ BonxaiMapsManager::on_initialize()
 
   if (!package_name.empty() && !occmap_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-      map_path_ = pkgpath + std::string("/") + occmap_path_file;
+      const std::filesystem::path pkgpath = ament_index_cpp::get_package_share_path(package_name);
+      map_path_ = (pkgpath / occmap_path_file).string();
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
     }

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 
@@ -24,7 +25,7 @@
 #include "easynav_costmap_maps_manager/map_io.hpp"
 #include "easynav_common/RTTFBuffer.hpp"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace easynav
@@ -110,8 +111,8 @@ CostmapMapsManager::on_initialize()
   map_path_ = "/tmp/default.map.yaml";
   if (!package_name.empty() && !map_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-      map_path_ = pkgpath + std::string("/") + map_path_file;
+      const std::filesystem::path pkgpath = ament_index_cpp::get_package_share_path(package_name);
+      map_path_ = (pkgpath / map_path_file).string();
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
     }

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 
@@ -26,7 +27,7 @@
 #include "navmap_ros/navmap_io.hpp"
 #include "easynav_navmap_maps_manager/map_io.hpp"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 namespace easynav
@@ -122,8 +123,8 @@ NavMapMapsManager::on_initialize()
 
   if (!package_name.empty() && !occmap_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-      map_path_ = pkgpath + std::string("/") + occmap_path_file;
+      const std::filesystem::path pkgpath = ament_index_cpp::get_package_share_path(package_name);
+      map_path_ = (pkgpath / occmap_path_file).string();
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
     }
@@ -145,8 +146,8 @@ NavMapMapsManager::on_initialize()
 
   if (!package_name.empty() && !navmap_path_file.empty()) {
     try {
-      const std::string pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-      map_path_ = pkgpath + std::string("/") + navmap_path_file;
+      const std::filesystem::path pkgpath = ament_index_cpp::get_package_share_path(package_name);
+      map_path_ = (pkgpath / navmap_path_file).string();
     } catch (ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
     }

--- a/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
+++ b/maps_managers/easynav_routes_maps_manager/src/easynav_routes_maps_manager/RoutesMapsManager.cpp
@@ -17,11 +17,12 @@
 #include "easynav_routes_maps_manager/RoutesMapsManager.hpp"
 #include "easynav_common/RTTFBuffer.hpp"
 
+#include <filesystem>
 #include <fstream>
 
 #include <yaml-cpp/yaml.h>
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -84,8 +85,8 @@ void RoutesMapsManager::on_initialize()
     // Absolute path: ignore package_name.
     map_path_ = map_path_file;
   } else if (!package_name.empty() && !map_path_file.empty()) {
-    const auto pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-    map_path_ = pkgpath + "/" + map_path_file;
+    const auto pkgpath = ament_index_cpp::get_package_share_path(package_name);
+    map_path_ = (pkgpath / map_path_file).string();
   } else {
     throw std::runtime_error(
       "Parameters '" + plugin_name + ".package' and '" + plugin_name +

--- a/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
+++ b/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
@@ -16,10 +16,12 @@
 /// \file
 /// \brief Implementation of the SimpleMapsManager class.
 
+#include <filesystem>
+
 #include "easynav_simple_maps_manager/SimpleMapsManager.hpp"
 #include "easynav_sensors/types/PointPerception.hpp"
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_share_path.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 #include "easynav_common/YTSession.hpp"
@@ -60,10 +62,10 @@ SimpleMapsManager::on_initialize()
 
   map_path_ = "/tmp/default.map";
   if (package_name != "" && map_path_file != "") {
-    std::string pkgpath;
+    std::filesystem::path pkgpath;
     try {
-      pkgpath = ament_index_cpp::get_package_share_directory(package_name);
-      map_path_ = pkgpath + "/" + map_path_file;
+      pkgpath = ament_index_cpp::get_package_share_path(package_name);
+      map_path_ = (pkgpath / map_path_file).string();
     } catch(ament_index_cpp::PackageNotFoundError & ex) {
       throw std::runtime_error("Package " + package_name + " not found. Error: " + ex.what());
     }


### PR DESCRIPTION
Hi,

This PR remove deprecated `get_package_share_directory`, replacing by ` get_package_share_path`

Best