### PR TITLE
Fix std::normal_distribution when stdev is zero

### DIFF
--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -545,18 +545,17 @@ AMCLLocalizer::predict([[maybe_unused]] NavState & nav_state)
   double rot_len = std::abs(yaw);
 
 
+  std::normal_distribution<double> noise_dx(
+    0.0, std::max(std::abs(dx) * noise_translation_, 1e-12));
+  std::normal_distribution<double> noise_dy(
+    0.0, std::max(std::abs(dy) * noise_translation_, 1e-12));
+  std::normal_distribution<double> noise_dz(
+    0.0, std::max(std::abs(dz) * noise_translation_, 1e-12));
+  std::normal_distribution<double> noise_yaw(
+    0.0,
+    std::max(rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_, 1e-12));
+
   for (auto & p : particles_) {
-    std::normal_distribution<double> noise_dx(
-      0.0, std::max(std::abs(dx) * noise_translation_, 1e-12));
-    std::normal_distribution<double> noise_dy(
-      0.0, std::max(std::abs(dy) * noise_translation_, 1e-12));
-    std::normal_distribution<double> noise_dz(
-      0.0, std::max(std::abs(dz) * noise_translation_, 1e-12));
-
-    std::normal_distribution<double> noise_yaw(
-      0.0,
-      std::max(rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_, 1e-12));
-
     tf2::Vector3 noisy_translation(
       dx + noise_dx(rng_),
       dy + noise_dy(rng_),

--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -242,9 +242,9 @@ AMCLLocalizer::on_initialize()
   RCLCPP_INFO(node->get_logger(), "at position (%lf, %lf, %lf) std_dev [%lf, %lf]",
     x_init, y_init, yaw_init, std_dev_xy, std_dev_yaw);
 
-  std::normal_distribution<double> noise_x(x_init, std_dev_xy);
-  std::normal_distribution<double> noise_y(y_init, std_dev_xy);
-  std::normal_distribution<double> noise_yaw(yaw_init, std_dev_yaw);
+  std::normal_distribution<double> noise_x(x_init, std::max(std_dev_xy, 1e-12));
+  std::normal_distribution<double> noise_y(y_init, std::max(std_dev_xy, 1e-12));
+  std::normal_distribution<double> noise_yaw(yaw_init, std::max(std_dev_yaw, 1e-12));
 
   particles_.resize(num_particles);
   for (auto & p : particles_) {
@@ -430,7 +430,7 @@ AMCLLocalizer::init_pose_callback(
   yaw_stddev = std::max(yaw_stddev, min_noise_yaw_);
 
   std::normal_distribution<double> standard_normal(0.0, 1.0);
-  std::normal_distribution<double> yaw_noise(0.0, yaw_stddev);
+  std::normal_distribution<double> yaw_noise(0.0, std::max(yaw_stddev, 1e-12));
 
   const std::size_t N = particles_.size();
 
@@ -546,13 +546,16 @@ AMCLLocalizer::predict([[maybe_unused]] NavState & nav_state)
 
 
   for (auto & p : particles_) {
-    std::normal_distribution<double> noise_dx(0.0, std::abs(dx) * noise_translation_);
-    std::normal_distribution<double> noise_dy(0.0, std::abs(dy) * noise_translation_);
-    std::normal_distribution<double> noise_dz(0.0, std::abs(dz) * noise_translation_);
+    std::normal_distribution<double> noise_dx(
+      0.0, std::max(std::abs(dx) * noise_translation_, 1e-12));
+    std::normal_distribution<double> noise_dy(
+      0.0, std::max(std::abs(dy) * noise_translation_, 1e-12));
+    std::normal_distribution<double> noise_dz(
+      0.0, std::max(std::abs(dz) * noise_translation_, 1e-12));
 
     std::normal_distribution<double> noise_yaw(
       0.0,
-      rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_);
+      std::max(rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_, 1e-12));
 
     tf2::Vector3 noisy_translation(
       dx + noise_dx(rng_),
@@ -680,7 +683,7 @@ AMCLLocalizer::reseed()
   double yaw_variance = computeYawVariance(particles_, 0, N_top);
   double yaw_stddev = std::sqrt(yaw_variance);
   std::normal_distribution<double> yaw_noise(0.0, std::max(yaw_stddev, min_noise_yaw_));
-  std::normal_distribution<double> index_dist(0.0, 0.05 * static_cast<double>(N));
+  std::normal_distribution<double> index_dist(0.0, std::max(0.05 * static_cast<double>(N), 1e-12));
   std::normal_distribution<double> standard_normal(0.0, 1.0);
 
   for (std::size_t i = N_top; i < N; ++i) {

--- a/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
@@ -239,9 +239,9 @@ AMCLLocalizer::on_initialize()
   RCLCPP_INFO(node->get_logger(), "at position (%lf, %lf, %lf) std_dev [%lf, %lf]",
     x_init, y_init, yaw_init, std_dev_xy, std_dev_yaw);
 
-  std::normal_distribution<double> noise_x(x_init, std_dev_xy);
-  std::normal_distribution<double> noise_y(y_init, std_dev_xy);
-  std::normal_distribution<double> noise_yaw(yaw_init, std_dev_yaw);
+  std::normal_distribution<double> noise_x(x_init, std::max(std_dev_xy, 1e-12));
+  std::normal_distribution<double> noise_y(y_init, std::max(std_dev_xy, 1e-12));
+  std::normal_distribution<double> noise_yaw(yaw_init, std::max(std_dev_yaw, 1e-12));
 
   particles_.resize(num_particles);
   for (auto & p : particles_) {
@@ -425,7 +425,7 @@ AMCLLocalizer::init_pose_callback(
   yaw_stddev = std::max(yaw_stddev, min_noise_yaw_);
 
   std::normal_distribution<double> standard_normal(0.0, 1.0);
-  std::normal_distribution<double> yaw_noise(0.0, yaw_stddev);
+  std::normal_distribution<double> yaw_noise(0.0, std::max(yaw_stddev, 1e-12));
 
   const std::size_t N = particles_.size();
   for (std::size_t i = 0; i < N; ++i) {
@@ -503,13 +503,16 @@ AMCLLocalizer::predict([[maybe_unused]] NavState & nav_state)
   std::mt19937 gen(rd());
 
   for (auto & p : particles_) {
-    std::normal_distribution<double> noise_dx(0.0, std::abs(dx) * noise_translation_);
-    std::normal_distribution<double> noise_dy(0.0, std::abs(dy) * noise_translation_);
-    std::normal_distribution<double> noise_dz(0.0, std::abs(dz) * noise_translation_);
+    std::normal_distribution<double> noise_dx(
+      0.0, std::max(std::abs(dx) * noise_translation_, 1e-12));
+    std::normal_distribution<double> noise_dy(
+      0.0, std::max(std::abs(dy) * noise_translation_, 1e-12));
+    std::normal_distribution<double> noise_dz(
+      0.0, std::max(std::abs(dz) * noise_translation_, 1e-12));
 
     std::normal_distribution<double> noise_yaw(
       0.0,
-      rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_);
+      std::max(rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_, 1e-12));
 
     tf2::Vector3 noisy_translation(
       dx + noise_dx(gen),
@@ -636,7 +639,7 @@ AMCLLocalizer::reseed()
   double yaw_variance = computeYawVariance(particles_, 0, N_top);
   double yaw_stddev = std::sqrt(yaw_variance);
   std::normal_distribution<double> yaw_noise(0.0, std::max(yaw_stddev, min_noise_yaw_));
-  std::normal_distribution<double> index_dist(0.0, 0.05 * static_cast<double>(N));
+  std::normal_distribution<double> index_dist(0.0, std::max(0.05 * static_cast<double>(N), 1e-12));
   std::normal_distribution<double> standard_normal(0.0, 1.0);
 
   for (std::size_t i = N_top; i < N; ++i) {

--- a/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
@@ -502,18 +502,17 @@ AMCLLocalizer::predict([[maybe_unused]] NavState & nav_state)
   std::random_device rd;
   std::mt19937 gen(rd());
 
+  std::normal_distribution<double> noise_dx(
+    0.0, std::max(std::abs(dx) * noise_translation_, 1e-12));
+  std::normal_distribution<double> noise_dy(
+    0.0, std::max(std::abs(dy) * noise_translation_, 1e-12));
+  std::normal_distribution<double> noise_dz(
+    0.0, std::max(std::abs(dz) * noise_translation_, 1e-12));
+  std::normal_distribution<double> noise_yaw(
+    0.0,
+    std::max(rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_, 1e-12));
+
   for (auto & p : particles_) {
-    std::normal_distribution<double> noise_dx(
-      0.0, std::max(std::abs(dx) * noise_translation_, 1e-12));
-    std::normal_distribution<double> noise_dy(
-      0.0, std::max(std::abs(dy) * noise_translation_, 1e-12));
-    std::normal_distribution<double> noise_dz(
-      0.0, std::max(std::abs(dz) * noise_translation_, 1e-12));
-
-    std::normal_distribution<double> noise_yaw(
-      0.0,
-      std::max(rot_len * noise_rotation_ + trans_len * noise_translation_to_rotation_, 1e-12));
-
     tf2::Vector3 noisy_translation(
       dx + noise_dx(gen),
       dy + noise_dy(gen),


### PR DESCRIPTION
Dear EasyNavers,

I found this execution error in Ubuntu 26.04:

```
[system_main-1] [WARN] [1784822583.116930278] [localizer_node]: [costmap] RT cycle time exceeded target by more than 1.5x (37.950 s > 0.020 s)
[system_main-1] /usr/include/c++/15/bits/random.h:2138: std::normal_distribution<_RealType>::param_type::param_type(_RealType, _RealType) [with _RealType = double]: Assertion '_M_stddev > _RealType(0)' failed.
[system_main-1] Magick: abort due to signal 6 (SIGABRT) "Abort"...
```

This PR fixes this bug by using a minumun of 1e-12 for stdev.

I hope it helps!!!

