### PR TITLE
Fix warnings

### DIFF
--- a/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
+++ b/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp
@@ -642,6 +642,10 @@ SerestController::update_rt(NavState & nav_state)
   if (nav_state.has("goal_tolerance.yaw")) {
     goal_yaw_tol = nav_state.get<double>("goal_tolerance.yaw");
   }
+  // Propagate the resolved tolerances to the members consumed by compute_goal_zone()
+  // and maybe_final_align_and_publish(), so a GoalManager override actually takes effect.
+  goal_pos_tol_ = goal_pos_tol;
+  goal_yaw_tol_deg_ = goal_yaw_tol * (180.0 / M_PI);
 
   // 2) Robot state (position + yaw)
   Vec2 robot_xy; double yaw = 0.0;

--- a/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_costmap_localizer/src/easynav_costmap_localizer/AMCLLocalizer.cpp
@@ -189,7 +189,7 @@ AMCLLocalizer::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  int num_particles;
+  int num_particles = 100;
   double x_init, y_init, yaw_init, std_dev_xy, std_dev_yaw;
 
   node->declare_parameter<int>(plugin_name + ".num_particles", 100);

--- a/localizers/easynav_fusion_localizer/tests/fusion_localizer_tests.cpp
+++ b/localizers/easynav_fusion_localizer/tests/fusion_localizer_tests.cpp
@@ -61,10 +61,6 @@ protected:
 
 TEST_F(FusionLocalizerInitialPoseTest, SubscribesToInitialPoseWithDefaultCallbackGroup)
 {
-  const double x0 = 1.5;
-  const double y0 = -0.25;
-  const double yaw0 = 0.7;
-
   const double x1 = -0.8;
   const double y1 = 2.1;
   const double yaw1 = -1.2;

--- a/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
+++ b/localizers/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
@@ -187,7 +187,7 @@ AMCLLocalizer::on_initialize()
   auto node = get_node();
   const auto & plugin_name = get_plugin_name();
 
-  int num_particles;
+  int num_particles = 100;
   double x_init, y_init, yaw_init, std_dev_xy, std_dev_yaw;
 
   node->declare_parameter<int>(plugin_name + ".num_particles", 100);

--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/InflationFilter.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/filters/InflationFilter.cpp
@@ -145,9 +145,8 @@ InflationFilter::update(NavState & nav_state)
 
   updateCosts(dynamic_map, min_i, min_j, max_i, max_j);
 
-  for (int i = 0; i < dynamic_map.getSizeInCellsX(); i++) {
-    for (int j = 0; j < dynamic_map.getSizeInCellsY(); j++) {
-      int index = static_cast<int>(dynamic_map.getIndex(i, j));
+  for (int i = 0; i < size_x; i++) {
+    for (int j = 0; j < size_y; j++) {
       unsigned char cost = std::max(
         dynamic_map.getCost(i, j), base_inflated_.getCost(i, j));
       dynamic_map.setCost(i, j, cost);


### PR DESCRIPTION
Hi,

This PR removes the warnings in the compilation. While this process, I discovered a real bug.

I hope it helps!!!



### Bug fixes

- **`easynav_plugins/controllers/easynav_serest_controller/src/easynav_serest_controller/SerestController.cpp`**: `update_rt()` computed `goal_pos_tol`/`goal_yaw_tol` from a `GoalManager`-provided override (`nav_state` keys `goal_tolerance.position` / `goal_tolerance.yaw`) but never applied them — `compute_goal_zone()` and `maybe_final_align_and_publish()` only ever read the member defaults `goal_pos_tol_` / `goal_yaw_tol_deg_`. The resolved override is now written back into those members before use, so a shared `GoalManager` tolerance actually takes effect instead of being silently discarded.

### Warning cleanup

- **`easynav_plugins/localizers/easynav_simple_localizer` and `easynav_costmap_localizer` (`AMCLLocalizer.cpp`)**: initialized `num_particles` at declaration (`= 100`, matching the `declare_parameter` default) to silence `-Wuninitialized`/`-Wmaybe-uninitialized` from the `get_parameter<int>()` call.
- **`easynav_plugins/localizers/easynav_fusion_localizer/tests/fusion_localizer_tests.cpp`**: removed dead `x0`/`y0`/`yaw0` locals left over from an earlier version of the test (`-Wunused-variable`); the test only exercises `x1`/`y1`/`yaw1`.
- **`easynav_plugins/maps_managers/easynav_costmap_maps_manager/.../filters/InflationFilter.cpp`**: the cost-update loop now bounds on the already-computed `int size_x`/`size_y` instead of calling `getSizeInCellsX()`/`getSizeInCellsY()` (`unsigned int`) again, fixing `-Wsign-compare`; also dropped an unused `index` local.

