### PR TITLE
Fix std::bad_alloc

### DIFF
--- a/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
+++ b/maps_managers/easynav_costmap_maps_manager/src/easynav_costmap_maps_manager/CostmapMapsManager.cpp
@@ -134,7 +134,7 @@ CostmapMapsManager::on_initialize()
     [&](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
       base_grid_msg_ = *msg;
 
-      base_grid_msg_.header.frame_id = tf_info.map_frame;
+      base_grid_msg_.header.frame_id = RTTFBuffer::getInstance()->get_tf_info().map_frame;
       base_grid_msg_.header.stamp = this->get_node()->now();
 
       map_base_ = Costmap2D(base_grid_msg_);

--- a/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
+++ b/maps_managers/easynav_navmap_maps_manager/src/easynav_navmap_maps_manager/NavMapMapsManager.cpp
@@ -170,7 +170,7 @@ NavMapMapsManager::on_initialize()
       navmap_ = navmap_ros::from_occupancy_grid(*msg);
 
       navmap_msg_ = navmap_ros::to_msg(navmap_);
-      navmap_msg_.header.frame_id = tf_info.map_frame;
+      navmap_msg_.header.frame_id = RTTFBuffer::getInstance()->get_tf_info().map_frame;
       navmap_msg_.header.stamp = this->get_node()->now();
       navmap_pub_->publish(navmap_msg_);
     });
@@ -184,7 +184,7 @@ NavMapMapsManager::on_initialize()
       navmap_ = navmap_ros::from_pointcloud2(*msg, navmap_msg_, params);
 
 
-      navmap_msg_.header.frame_id = tf_info.map_frame;
+      navmap_msg_.header.frame_id = RTTFBuffer::getInstance()->get_tf_info().map_frame;
       navmap_msg_.header.stamp = this->get_node()->now();
       navmap_pub_->publish(navmap_msg_);
     });

--- a/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
+++ b/maps_managers/easynav_octomap_maps_manager/src/easynav_octomap_maps_manager/OctomapMapsManager.cpp
@@ -166,8 +166,6 @@ OctomapMapsManager::on_initialize()
 //      octomap_pub_->publish(octomap_msg_);
 //    });
 
-  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();
-
   incoming_pc2_map_sub_ = node->create_subscription<sensor_msgs::msg::PointCloud2>(
     node->get_fully_qualified_name() + std::string("/") + plugin_name + "/incoming_pc2_map",
     rclcpp::QoS(100),
@@ -176,8 +174,8 @@ OctomapMapsManager::on_initialize()
       geometry_msgs::msg::TransformStamped tf_msg;
       try {
         tf_msg = RTTFBuffer::getInstance()->lookupTransform(
-          tf_info.map_frame, msg->header.frame_id, msg->header.stamp,
-            rclcpp::Duration::from_seconds(0.05));
+          RTTFBuffer::getInstance()->get_tf_info().map_frame, msg->header.frame_id,
+          msg->header.stamp, rclcpp::Duration::from_seconds(0.05));
       } catch (const tf2::TransformException & ex) {
         RCLCPP_WARN(get_node()->get_logger(), "OctomapMapsManager: TF failed: %s", ex.what());
         return;
@@ -220,7 +218,7 @@ OctomapMapsManager::on_initialize()
       octomap_->insertPointCloud(cloud, origin, 1000.0, true, false);
       octomap_->updateInnerOccupancy();
 
-      octomap_msg_.header.frame_id = tf_info.map_frame;
+      octomap_msg_.header.frame_id = RTTFBuffer::getInstance()->get_tf_info().map_frame;
       octomap_msg_.header.stamp = this->get_node()->now();
       octomap_msg_.id = "OcTree";
       octomap_msg_.binary = true;

--- a/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
+++ b/maps_managers/easynav_simple_maps_manager/src/easynav_simple_maps_manager/SimpleMapsManager.cpp
@@ -90,7 +90,7 @@ SimpleMapsManager::on_initialize()
       dynamic_map_.from_occupancy_grid(*msg);
 
       static_map_.to_occupancy_grid(static_grid_msg_);
-      static_grid_msg_.header.frame_id = tf_info.map_frame;
+      static_grid_msg_.header.frame_id = RTTFBuffer::getInstance()->get_tf_info().map_frame;
       static_grid_msg_.header.stamp = this->get_node()->now();
 
       static_occ_pub_->publish(static_grid_msg_);


### PR DESCRIPTION
Hi, 

This PR fixes a dangling `tf_info` reference in async map-topic callbacks. `RTTFBuffer::get_tf_info()` returns `TFInfo` **by value** (a locked snapshot copy). Several `on_initialize()` methods did:

  ```cpp
  const auto & tf_info = RTTFBuffer::getInstance()->get_tf_info();  // binds to a temporary
  ...
  incoming_map_sub_ = node->create_subscription<...>(..., [&](...) {
    ... tf_info.map_frame ...   // captured by reference
  });
  ```
  Temporary lifetime extension only keeps the temporary alive until `tf_info` itself goes out of scope, i.e. until `on_initialize()` returns. The subscription lambda captures `tf_info` by reference (`[&]`) and is invoked later, after that scope has ended, so `tf_info` is dangling by the time a message arrives. Reading `tf_info.map_frame` then interprets freed memory as a `std::string`, producing a garbage size and an `operator new` call that throws `std::bad_alloc`.

To fix it, inside each async callback, fetch a fresh snapshot at the point of use (`RTTFBuffer::getInstance()->get_tf_info().map_frame`) instead of reusing the captured reference. Synchronous uses of `tf_info` within `on_initialize()`'s own scope are untouched as those are safe.

This bug affected to :
  - `easynav_costmap_maps_manager` — `CostmapMapsManager.cpp`
  - `easynav_simple_maps_manager` — `SimpleMapsManager.cpp`
  - `easynav_navmap_maps_manager` — `NavMapMapsManager.cpp` (two callbacks: `incoming_occ_map`, `incoming_pc2_map`)
  - `easynav_octomap_maps_manager` — `OctomapMapsManager.cpp` (`incoming_pc2_map`; also dropped the now-unused outer `tf_info` local)

